### PR TITLE
Accept benchmark functions in Eval

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 
 val scalazVersion     = "7.2.0"
 val spireVersion      = "0.11.0"
-val monocleVersion    = "1.2.0"
+val monocleVersion    = "1.2.2"
 val scalacheckVersion = "1.11.4"
 
 lazy val buildSettings = Seq(
@@ -221,6 +221,7 @@ lazy val example = project.dependsOn(core, exec, ga, moo, pso)
   .settings(noPublishSettings)
   .settings(Seq(
     libraryDependencies ++= Seq(
+      "net.cilib"  %% "benchmarks"        % "0.1",
       "org.scalaz" %% "scalaz-core"       % scalazVersion,
       "org.scalaz" %% "scalaz-concurrent" % scalazVersion,
       "org.scalaz" %% "scalaz-effect"     % scalazVersion,

--- a/core/src/main/scala/cilib/Constraint.scala
+++ b/core/src/main/scala/cilib/Constraint.scala
@@ -1,6 +1,6 @@
 package cilib
 
-import scalaz.Maybe
+import scalaz.{Maybe,NonEmptyList}
 import spire.algebra.Eq
 import spire.math._
 import spire.math.interval._
@@ -30,8 +30,8 @@ object ViolationCount {
   }
 }
 
-case class ConstraintFunction[A,B](f: List[A] => B) {
-  def apply(a: List[A]): B =
+case class ConstraintFunction[A,B](f: NonEmptyList[A] => B) {
+  def apply(a: NonEmptyList[A]): B =
     f(a)
 }
 
@@ -46,10 +46,10 @@ case class GreaterThanEqual[A,B](f: ConstraintFunction[A,B], v: B) extends Const
 object Constraint {
 
   import scalaz.{Foldable, Functor}
-  def constrain[M[_]](ma: M[Eval[Double]], cs: List[Constraint[Double,Double]])(implicit M: Functor[M]) =
-    M.map(ma)(_.constrainBy(cs))
+//  def constrain[M[_]](ma: M[Eval[Double]], cs: List[Constraint[Double,Double]])(implicit M: Functor[M]) =
+//    M.map(ma)(_.constrainBy(cs))
 
-  def violationMagnitude[A,B:Fractional](beta: Double, eta: Double, constraints: List[Constraint[A,B]], cs: List[A])(implicit e: Eq[B]): Double =
+  def violationMagnitude[A,B:Fractional](beta: Double, eta: Double, constraints: List[Constraint[A,B]], cs: NonEmptyList[A])(implicit e: Eq[B]): Double =
     constraints.map(_ match {
       case LessThan(f, v) =>
         val v2 = f(cs)
@@ -101,10 +101,10 @@ object Constraint {
         else math.pow(math.abs(v2.toDouble + v.toDouble), beta) + eta
     }).sum
 
-  def violationCount[A,B:Fractional](constraints: List[Constraint[A,B]], cs: List[A]): ViolationCount =
+  def violationCount[A,B:Fractional](constraints: List[Constraint[A,B]], cs: NonEmptyList[A]): ViolationCount =
     ViolationCount(constraints.map(satisfies(_, cs)).filterNot(x => x).length).getOrElse(ViolationCount.zero)
 
-  def satisfies[A,B:Fractional](constraint: Constraint[A,B], cs: List[A])(implicit ev: Eq[B]) =
+  def satisfies[A,B:Fractional](constraint: Constraint[A,B], cs: NonEmptyList[A])(implicit ev: Eq[B]) =
     constraint match {
       case LessThan(f, v) => f(cs) < v
       case LessThanEqual(f, v) => f(cs) <= v

--- a/core/src/main/scala/cilib/Entity.scala
+++ b/core/src/main/scala/cilib/Entity.scala
@@ -70,6 +70,9 @@ sealed abstract class Position[A] {
       case Point(_, b)       => b
       case Solution(_, b, _) => b
     }
+
+  def forall(f: A => Boolean) =
+    pos.list.toList.forall(f)
 }
 
 final case class Point[A] private[cilib] (x: NonEmptyList[A], b: NonEmptyList[Interval[Double]]) extends Position[A]

--- a/core/src/main/scala/cilib/Entity.scala
+++ b/core/src/main/scala/cilib/Entity.scala
@@ -35,6 +35,18 @@ sealed abstract class Position[A] {
   def traverse[G[_]: Applicative, B](f: A => G[B]): G[Position[B]] =
     pos.traverse(f).map(Point(_, boundary))
 
+  def take(n: Int): IList[A] =
+    this match {
+      case Point(x, _) => x.list.take(n)
+      case Solution(x,_,_) => x.list.take(n)
+    }
+
+  def drop(n: Int): IList[A] =
+    this match {
+      case Point(x, _) => x.list.drop(n)
+      case Solution(x, _, _) => x.list.drop(n)
+    }
+
   def pos =
     this match {
       case Point(x, _)       => x
@@ -60,8 +72,8 @@ sealed abstract class Position[A] {
     }
 }
 
-final case class Point[A] private[cilib] (x: List[A], b: NonEmptyList[Interval[Double]]) extends Position[A]
-final case class Solution[A] private[cilib] (x: List[A], b: NonEmptyList[Interval[Double]], o: Objective[A]) extends Position[A]
+final case class Point[A] private[cilib] (x: NonEmptyList[A], b: NonEmptyList[Interval[Double]]) extends Position[A]
+final case class Solution[A] private[cilib] (x: NonEmptyList[A], b: NonEmptyList[Interval[Double]], o: Objective[A]) extends Position[A]
 
 object Position {
 
@@ -109,7 +121,15 @@ object Position {
     def unary_-(implicit M: Module[Position[A],A]): Position[A] =
       M.negate(x)
 
-    def isZero(implicit R: Ring[A]) = x.pos.forall(_ == R.zero)
+    def isZero(implicit R: Ring[A]) = {
+      def test(xs: IList[A]): Boolean =
+        xs match {
+          case INil() => true
+          case ICons(x, xss) => if (x != R.zero) false else test(xss)
+        }
+
+      test(x.pos.list)
+    }
 
   }
 
@@ -121,8 +141,26 @@ object Position {
   implicit def positionEqual[A:scalaz.Equal] =
     scalaz.Equal.equal[Position[A]]((a, b) => (a.pos === b.pos) && (a.boundary === b.boundary))
 
-  def apply[A](xs: NonEmptyList[A], b: NonEmptyList[Interval[Double]]): Position[A] =
-    Point(xs.list.toList, b)
+  implicit val positionFoldable1 = new Foldable1[Position] {
+    def foldMap1[A, B](fa: Position[A])(f: A => B)(implicit F: Semigroup[B]): B =
+      fa match {
+        case Point(xs, _) =>
+          xs.foldMap1(f)
+        case Solution(xs, _, _) =>
+          xs.foldMap1(f)
+      }
+
+    def foldMapRight1[A, B](fa: Position[A])(z: A => B)(f: (A, => B) => B): B =
+      fa match {
+        case Point(xs, _) =>
+          xs.foldMapRight1(z)(f)
+        case Solution(xs, _, _) =>
+          xs.foldMapRight1(z)(f)
+      }
+  }
+
+  private[cilib] def apply[A](xs: NonEmptyList[A], b: NonEmptyList[Interval[Double]]): Position[A] =
+    Point(xs, b)
 
   def createPosition[A](domain: NonEmptyList[Interval[Double]]) =
     domain.traverseU(x => Dist.uniform(Interval(x.lowerValue, x.upperValue))) map (x => Position(x, domain))

--- a/core/src/main/scala/cilib/Lenses.scala
+++ b/core/src/main/scala/cilib/Lenses.scala
@@ -20,7 +20,7 @@ trait HasVelocity[S,A] {
   def _velocity: Lens[S, Position[A]]
 }
 
-object Velocity {
+object HasVelocity {
   implicit val memVelocity = new HasVelocity[Mem[Double],Double] {
     def _velocity = Lens[Mem[Double], Position[Double]](_.v)(b => a => a.copy(v = b))
   }

--- a/core/src/main/scala/cilib/Lenses.scala
+++ b/core/src/main/scala/cilib/Lenses.scala
@@ -4,33 +4,33 @@ import monocle._
 
 case class Mem[/*F[_],*/A](b: Position[A], v: Position[A])
 
-trait Memory[S,/*F[_],*/A] {
+trait HasMemory[S,/*F[_],*/A] {
   def _memory: Lens[S, Position[A]]
 }
 
-object Memory {
-  @inline def apply[S,A](implicit A: Memory[S,A]) = A
+object HasMemory {
+  @inline def apply[S,A](implicit A: HasMemory[S,A]) = A
 
-  implicit def memMemory/*[F[_]]*/ = new Memory[Mem[Double],Double] {
+  implicit def memMemory/*[F[_]]*/ = new HasMemory[Mem[Double],Double] {
     def _memory = Lens[Mem[Double],Position[Double]](_.b)(b => a => a.copy(b = b))
   }
 }
 
-trait Velocity[S,/*F[_],*/A] {
+trait HasVelocity[S,/*F[_],*/A] {
   def _velocity: Lens[S, Position[A]]
 }
 
-object Velocity {
-  implicit def memVelocity/*[F[_]]*/ = new Velocity[Mem[Double],Double] {
+object HasVelocity {
+  implicit def memVelocity/*[F[_]]*/ = new HasVelocity[Mem[Double],Double] {
     def _velocity = Lens[Mem[Double], Position[Double]](_.v)(b => a => a.copy(v = b))
   }
 }
 
-trait Charge[A] {
+trait HasCharge[A] {
   def _charge: Lens[A,Double]
 }
 
-trait PBestStagnation[A] {
+trait HasPBestStagnation[A] {
   def _pbestStagnation: Lens[A, Int]
 }
 

--- a/core/src/main/scala/cilib/Lenses.scala
+++ b/core/src/main/scala/cilib/Lenses.scala
@@ -2,26 +2,26 @@ package cilib
 
 import monocle._
 
-case class Mem[/*F[_],*/A](b: Position[A], v: Position[A])
+case class Mem[A](b: Position[A], v: Position[A])
 
-trait HasMemory[S,/*F[_],*/A] {
+trait HasMemory[S,A] {
   def _memory: Lens[S, Position[A]]
 }
 
 object HasMemory {
   @inline def apply[S,A](implicit A: HasMemory[S,A]) = A
 
-  implicit def memMemory/*[F[_]]*/ = new HasMemory[Mem[Double],Double] {
+  implicit val memMemory = new HasMemory[Mem[Double],Double] {
     def _memory = Lens[Mem[Double],Position[Double]](_.b)(b => a => a.copy(b = b))
   }
 }
 
-trait HasVelocity[S,/*F[_],*/A] {
+trait HasVelocity[S,A] {
   def _velocity: Lens[S, Position[A]]
 }
 
-object HasVelocity {
-  implicit def memVelocity/*[F[_]]*/ = new HasVelocity[Mem[Double],Double] {
+object Velocity {
+  implicit val memVelocity = new HasVelocity[Mem[Double],Double] {
     def _velocity = Lens[Mem[Double], Position[Double]](_.v)(b => a => a.copy(v = b))
   }
 }

--- a/core/src/main/scala/cilib/algebra/DotProd.scala
+++ b/core/src/main/scala/cilib/algebra/DotProd.scala
@@ -61,7 +61,7 @@ object Algebra {
     if   (D.dot(other, other) == F2.zero) F.map(other)(_ => F2.zero)
     else (D.dot(x, other) / D.dot(other, other)) *: other
 
-  def orthonormalize[F[_]:Functor:Foldable,A:NRoot](vs: NonEmptyList[F[A]])(
+  def orthonormalize[F[_]:Functor:Foldable1,A:NRoot](vs: NonEmptyList[F[A]])(
     implicit D: DotProd[F,A], M: Module[F[A],Double], A: Field[A]) = {
     val bases = vs.foldLeft(NonEmptyList(vs.head)) { (ob, v) =>
       val ui = ob.foldLeft(v) { (u, o) => u - project(v, o) }

--- a/core/src/main/scala/cilib/syntax/DotProd.scala
+++ b/core/src/main/scala/cilib/syntax/DotProd.scala
@@ -1,7 +1,7 @@
 package cilib
 package syntax
 
-import scalaz.{Foldable,Functor,NonEmptyList}
+import scalaz.{Foldable1,Functor,NonEmptyList}
 import spire.implicits._
 import spire.algebra._
 
@@ -19,7 +19,7 @@ object dotprod {
 
     def orthonormalize(
       implicit F: Functor[F],
-               F2: Foldable[F],
+               F2: Foldable1[F],
                F3: Field[A],
                A: NRoot[A],
                D: DotProd[F,A],

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -5,6 +5,7 @@ import scalaz.Kleisli
 import scalaz.effect._
 import scalaz.effect.IO.putStrLn
 import scalaz.std.list._
+import scalaz.std.option._
 import scalaz.syntax.std.list._
 import scalaz.syntax.traverse._
 import spire.implicits._
@@ -14,16 +15,16 @@ import cilib.ga._
 import Lenses._
 
 object GAExample extends SafeApp {
-  val sum = Problems.spherical[Double]
+  val sum = Problems.spherical
 
   def onePoint(xs: List[Individual]): RVar[List[Individual]] =
     xs match {
       case a :: b :: _ =>
         val point: RVar[Int] = Dist.uniformInt(Interval(0, a.pos.pos.size - 1))
         point.map(p => List(
-          a.pos.pos.take(p) ++ b.pos.pos.drop(p),
-          b.pos.pos.take(p) ++ a.pos.pos.drop(p)
-        ).map(x => Entity((), Point(x, a.pos.boundary))))
+          a.pos.take(p) ++ b.pos.drop(p),
+          b.pos.take(p) ++ a.pos.drop(p)
+        ).traverse(_.toNel.map(x => Entity((), Point(x, a.pos.boundary)))).getOrElse(List.empty[Individual]))
       case _ => sys.error("Incorrect number of parents")
     }
 

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -19,7 +19,7 @@ import Scalaz._
 object GBestPSO extends SafeApp {
 
   // Create a problem by specifiying the function and it's constrainment
-  val sum = Problems.spherical[Double]
+  val sum = Problems.spherical
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double],Double]

--- a/example/src/main/scala/cilib/example/Heterogeneous.scala
+++ b/example/src/main/scala/cilib/example/Heterogeneous.scala
@@ -31,15 +31,15 @@ object HPSO extends SafeApp {
   object PState {
     implicit val myParticleMemLens = monocle.Lens[PState, Mem[Double]](_.mem)(b => a => a.copy(mem = b))
 
-    implicit object PStateMemory extends Memory[PState,Double] {
-      def _memory = PState.myParticleMemLens ^|-> Memory.memMemory._memory
+    implicit object PStateMemory extends HasMemory[PState,Double] {
+      def _memory = PState.myParticleMemLens ^|-> HasMemory.memMemory._memory
     }
 
-    implicit object PStateVelocity extends Velocity[PState,Double] {
-      def _velocity = PState.myParticleMemLens ^|-> Velocity.memVelocity._velocity
+    implicit object PStateVelocity extends HasVelocity[PState,Double] {
+      def _velocity = PState.myParticleMemLens ^|-> HasVelocity.memVelocity._velocity
     }
 
-    implicit object PStatePBestStagnation extends PBestStagnation[PState] {
+    implicit object PStatePBestStagnation extends HasPBestStagnation[PState] {
       def _pbestStagnation = monocle.Lens[PState, Int](_.stag)(b => a => a.copy(stag = b))
     }
   }

--- a/example/src/main/scala/cilib/example/LBestPSO.scala
+++ b/example/src/main/scala/cilib/example/LBestPSO.scala
@@ -14,7 +14,7 @@ import cilib.syntax.algorithm._
 
 object LBestPSO extends SafeApp {
 
-  val sum = Problems.spherical[Double]
+  val sum = Problems.spherical
 
   // LBest is a network topology where every Paricle 'x' has (n/2) neighbours
   // on each side. For example, a neighbourhood size of 3 means that there is

--- a/example/src/main/scala/cilib/example/NMPCPSO.scala
+++ b/example/src/main/scala/cilib/example/NMPCPSO.scala
@@ -12,7 +12,7 @@ import spire.math.Interval
 
 object NMPCPSO extends SafeApp {
 
-  val sum = Problems.spherical[Double]
+  val sum = Problems.spherical
 
   val guide = Guide.nmpc[Mem[Double]](0.5)
   val nmpcPSO = nmpc(guide)

--- a/example/src/main/scala/cilib/example/PCXPSO.scala
+++ b/example/src/main/scala/cilib/example/PCXPSO.scala
@@ -12,7 +12,7 @@ import spire.math.Interval
 
 object PCXPSO extends SafeApp {
 
-  val sum = Problems.spherical[Double]
+  val sum = Problems.spherical
 
   val guide = Guide.pcx[Mem[Double]](2.0, 2.0)
   val pcxPSO = crossoverPSO(guide)

--- a/example/src/main/scala/cilib/example/UNDXPSO.scala
+++ b/example/src/main/scala/cilib/example/UNDXPSO.scala
@@ -12,7 +12,7 @@ import spire.math.Interval
 
 object UNDXPSO extends SafeApp {
 
-  val sum = Problems.spherical[Double]
+  val sum = Problems.spherical
 
   val guide = Guide.undx[Mem[Double]](1.0, 0.1)
   val undxPSO = crossoverPSO(guide)

--- a/example/src/main/scala/cilib/example/VonNeumannPSO.scala
+++ b/example/src/main/scala/cilib/example/VonNeumannPSO.scala
@@ -19,7 +19,7 @@ import Scalaz._
 object VonNeumannPSO extends SafeApp {
 
   // Create a problem by specifiying the function and it's constrainment
-  val sum = Problems.spherical[Double]
+  val sum = Problems.spherical
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double],Double]

--- a/moo/src/main/scala/cilib/MultiEval.scala
+++ b/moo/src/main/scala/cilib/MultiEval.scala
@@ -1,7 +1,9 @@
 package cilib
 
+import scalaz.NonEmptyList
+
 final class MultiEval[A] private (objectives: List[Eval[A]]) {
-  def eval(xs: List[A]): List[Objective[A]] =
+  def eval(xs: NonEmptyList[A]): List[Objective[A]] =
     objectives.map(_.eval(xs))
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url(
 
 addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"  % "0.3.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-pgp"     % "0.8.3")
+//addSbtPlugin("com.typesafe.sbt"  % "sbt-pgp"     % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"    % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages" % "0.5.4")
 addSbtPlugin("org.tpolecat"      % "tut-plugin"  % "0.4.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += Resolver.url(
 addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"  % "0.3.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"     % "1.0.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-site"    % "1.0.0")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-site"    % "1.1.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages" % "0.5.4")
 addSbtPlugin("org.tpolecat"      % "tut-plugin"  % "0.4.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url(
 
 addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"  % "0.3.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
-//addSbtPlugin("com.typesafe.sbt"  % "sbt-pgp"     % "1.0.0")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"     % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"    % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages" % "0.5.4")
 addSbtPlugin("org.tpolecat"      % "tut-plugin"  % "0.4.2")

--- a/pso/src/main/scala/cilib/pso/Defaults.scala
+++ b/pso/src/main/scala/cilib/pso/Defaults.scala
@@ -16,7 +16,7 @@ object Defaults {
     c2: Double,
     cognitive: Guide[S,Double],
     social: Guide[S,Double]
-  )(implicit M: Memory[S,Double], V: Velocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
+  )(implicit M: HasMemory[S,Double], V: HasVelocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
     collection => x => for {
       cog     <- cognitive(collection, x)
       soc     <- social(collection, x)
@@ -31,7 +31,7 @@ object Defaults {
     w: Double,
     c1: Double,
     cognitive: Guide[S,Double]
-  )(implicit M: Memory[S,Double], V: Velocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
+  )(implicit M: HasMemory[S,Double], V: HasVelocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
     collection => x => {
       for {
         cog     <- cognitive(collection, x)
@@ -47,7 +47,7 @@ object Defaults {
     w: Double,
     c1: Double,
     social: Guide[S,Double]
-  )(implicit M: Memory[S,Double], V: Velocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
+  )(implicit M: HasMemory[S,Double], V: HasVelocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
     collection => x => {
       for {
         soc     <- social(collection, x)
@@ -69,7 +69,7 @@ object Defaults {
     w: Double,
     c1: Double,
     c2: Double,
-    cognitive: Guide[S,Double])(implicit M:Memory[S,Double], V:Velocity[S,Double]
+    cognitive: Guide[S,Double])(implicit M: HasMemory[S,Double], V: HasVelocity[S,Double]
   ): List[Particle[S,Double]] => Particle[S,Double] => StepS[Double, GCParams, Particle[S,Double]] =
     collection => x => StepS {
       val S = StateT.stateTMonadState[GCParams, Step[Double,?]]
@@ -97,7 +97,7 @@ object Defaults {
       } yield updated
     }
 
-  def charged[S:Charge](
+  def charged[S:HasCharge](
     w: Double,
     c1: Double,
     c2: Double,
@@ -106,7 +106,7 @@ object Defaults {
     distance: (Position[Double], Position[Double]) => Double,
     rp: Double,
     rc: Double
-  )(implicit M:Memory[S,Double], V:Velocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
+  )(implicit M:HasMemory[S,Double], V:HasVelocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
     collection => x => for {
       cog     <- cognitive(collection, x)
       soc     <- social(collection, x)
@@ -120,7 +120,7 @@ object Defaults {
 
   def nmpc[S](
     guide: Guide[S,Double]
-  )(implicit M: Memory[S,Double], V: Velocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
+  )(implicit M: HasMemory[S,Double], V: HasVelocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
     collection => x => for {
       p        <- evalParticle(x)
       p1       <- updatePBestBounds(p)
@@ -132,7 +132,7 @@ object Defaults {
 
   def crossoverPSO[S](
     guide: Guide[S,Double]
-  )(implicit M: Memory[S,Double], V: Velocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
+  )(implicit M: HasMemory[S,Double], V: HasVelocity[S,Double]): List[Particle[S,Double]] => Particle[S,Double] => Step[Double,Particle[S,Double]] =
     collection => x => for {
       p       <- evalParticle(x)
       p1      <- updatePBestBounds(p)

--- a/pso/src/main/scala/cilib/pso/Guide.scala
+++ b/pso/src/main/scala/cilib/pso/Guide.scala
@@ -11,10 +11,10 @@ object Guide {
   def identity[S,F[_],A]: Guide[S,A] =
     (_, x) => Step.point(x.pos)
 
-  def pbest[S,A](implicit M: Memory[S,A]): Guide[S,A] =
+  def pbest[S,A](implicit M: HasMemory[S,A]): Guide[S,A] =
     (_, x) => Step.point(M._memory.get(x.state))
 
-  def nbest[S](selection: Selection[Particle[S,Double]])(implicit M: Memory[S,Double]): Guide[S,Double] = {
+  def nbest[S](selection: Selection[Particle[S,Double]])(implicit M: HasMemory[S,Double]): Guide[S,Double] = {
     (collection, x) => Step.withCompare(o => RVar.point {
       val selected = selection(collection, x)
       val fittest = selected.map(e => M._memory.get(e.state)).reduceLeftOption((a, c) => Comparison.compare(a, c) run (o))
@@ -31,13 +31,13 @@ object Guide {
     })
   }
 
-  def gbest[S](implicit M: Memory[S,Double]): Guide[S,Double] =
+  def gbest[S](implicit M: HasMemory[S,Double]): Guide[S,Double] =
     nbest((c, _) => c)
 
-  def lbest[S](n: Int)(implicit M: Memory[S,Double]) =
+  def lbest[S](n: Int)(implicit M: HasMemory[S,Double]) =
     nbest(Selection.indexNeighbours[Particle[S,Double]](n))
 
-  def vonNeumann[S](implicit M: Memory[S,Double]) =
+  def vonNeumann[S](implicit M: HasMemory[S,Double]) =
     nbest((c: List[Particle[S,Double]], a: Particle[S,Double]) => {
       val np = c.length
       val index = c.indexOf(a)
@@ -74,7 +74,7 @@ object Guide {
       } yield zipped.map { case ((xi, ci), pi) => if (pi < prob) ci else xi }
     }
 
-  def pcx[S](s1: Double, s2: Double)(implicit M: Memory[S,Double]): Guide[S,Double] =
+  def pcx[S](s1: Double, s2: Double)(implicit M: HasMemory[S,Double]): Guide[S,Double] =
     (collection, x) => {
       val gb = gbest
       val pb = pbest
@@ -89,7 +89,7 @@ object Guide {
       } yield offspring.head
     }
 
-  def undx[S](s1: Double, s2: Double)(implicit M: Memory[S,Double]): Guide[S,Double] =
+  def undx[S](s1: Double, s2: Double)(implicit M: HasMemory[S,Double]): Guide[S,Double] =
     (collection, x) => {
       val gb = gbest
       val pb = pbest

--- a/pso/src/main/scala/cilib/pso/Heterogeneous.scala
+++ b/pso/src/main/scala/cilib/pso/Heterogeneous.scala
@@ -89,7 +89,7 @@ object Heterogeneous {
   type HEntityB[S, A, B] = HEntity[S, A, Behaviour[S, A, B]]
 
   // Helper functions
-  def updateStagnation[S, A](p: Entity[S,A])(implicit M: Memory[S,A], S: PBestStagnation[S]): Step[A, Entity[S,A]] = {
+  def updateStagnation[S, A](p: Entity[S,A])(implicit M: HasMemory[S,A], S: HasPBestStagnation[S]): Step[A, Entity[S,A]] = {
     val pbest = M._memory.get(p.state)
     val stagnationL = p.state applyLens S._pbestStagnation
     val stagnation = stagnationL.get
@@ -112,10 +112,10 @@ object Heterogeneous {
     } yield collection
 
   // Behaviour changing schedules will prolly change to RVar[Boolean] or maybe even Instruction
-  def pbestStagnated[S, A, B](threshold: Int)(implicit S: PBestStagnation[S]): HEntity[S,A,B] => Boolean =
+  def pbestStagnated[S, A, B](threshold: Int)(implicit S: HasPBestStagnation[S]): HEntity[S,A,B] => Boolean =
     x => (x.user.state applyLens S._pbestStagnation).get % threshold === 0
 
-  def resetStagnation[S, A, B](implicit S: PBestStagnation[S]): HEntity[S,A,B] => HEntity[S,A,B] =
+  def resetStagnation[S, A, B](implicit S: HasPBestStagnation[S]): HEntity[S,A,B] => HEntity[S,A,B] =
     x => User(Entity((x.user.state applyLens S._pbestStagnation) set 0, x.user.pos), x.item)
 
    // Select from behaviour pool
@@ -190,7 +190,7 @@ object Heterogeneous {
       } yield p2
     }
 
-  def dHPSO[S: PBestStagnation, A, B](stagThreshold: Int):
+  def dHPSO[S: HasPBestStagnation, A, B](stagThreshold: Int):
       List[HEntityB[S, A, B]] => HEntityB[S, A, B] => StepS[A, (Pool[Behaviour[S, A, B]], B), HEntityB[S, A, B]]
   = genericHPSO(
     pbestStagnated(stagThreshold),
@@ -198,7 +198,7 @@ object Heterogeneous {
     nullPoolUpdate
   )
 
-  def fkPSO[S: PBestStagnation, A, B](stagThreshold: Int, tournSize: Int):
+  def fkPSO[S: HasPBestStagnation, A, B](stagThreshold: Int, tournSize: Int):
       List[HEntityB[S, A, B]] => HEntityB[S, A, B] => StepS[A, (Pool[Behaviour[S, A, B]], B), HEntityB[S, A, B]]
   = genericHPSO(
     pbestStagnated(stagThreshold),

--- a/tests/src/test/scala/cilib/PositionTests.scala
+++ b/tests/src/test/scala/cilib/PositionTests.scala
@@ -83,16 +83,16 @@ object PositionTests extends Properties("Position") {
   }
 
   property("negation") = forAll { (a: Pos) =>
-    (a.foldLeft(0)(_+_) != 0) ==>
+    (a.foldLeft1(_+_) != 0) ==>
       (-a =/= a)                    &&
       -a          === a.map(_ * -1) &&
       a + (-a)    === a.zeroed
   }
 
   property("is zero") = forAll { (a: Pos) =>
-    a.zeroed.foldLeft(0)(_+_) === 0     &&
-    zero.foldLeft(0.0)(_+_).toInt === 0 &&
-    one.foldLeft(0.0)(_+_).toInt =/= 0
+    a.zeroed.foldLeft1(_+_) === 0     &&
+    zero.foldLeft1(_+_).toInt === 0 &&
+    one.foldLeft1(_+_).toInt =/= 0
   }
 
   property("dot product") = forAll { (ps: (Pos,Pos,Pos)) =>
@@ -110,9 +110,9 @@ object PositionTests extends Properties("Position") {
   }
 
   property("normalize") = forAll { (a: Position[Double]) =>
-    a.foldLeft(0.0)(_+_) =/= 0.0 ==>
-      (a.normalize.magnitude === 1.0)  &&
-      a.normalize.pos.forall(_ <= 1.0) &&
+    a.foldLeft1(_+_) =/= 0.0 ==>
+      (a.normalize.magnitude === 1.0) &&
+      a.normalize.forall(_ <= 1.0) &&
       zero.normalize.magnitude === 0.0
   }
 

--- a/tests/src/test/scala/cilib/StepTest.scala
+++ b/tests/src/test/scala/cilib/StepTest.scala
@@ -10,9 +10,9 @@ import org.scalacheck.Prop._
 import scalaz.scalacheck.ScalazProperties._
 
 object StepTest extends Spec("Step") {
-
+import Eval._
   val cmp = Comparison.quality(Min)
-  val eval = Unconstrained((l: List[Int]) => l.foldLeft(0.0)(_ + _))
+  val eval = Eval.unconstrained((l: NonEmptyList[Int]) => l.list.foldLeft(0.0)(_ + _))
   val rng = RNG.fromTime
 
   implicit def stepEqual = scalaz.Equal[Int].contramap((_: Step[Int,Int]).run.apply(cmp).apply(eval).run(rng)._2)


### PR DESCRIPTION
Additionally, rename all of the "classy lenses" to be prefixed
with "Has". eg: `Memory` -> `HasMemory`. This seems to be the
convention in the Haskell `lens` library usage as well, so
it's just better to be consistent.

Signed-off-by: Gary Pamparà <gpampara@gmail.com>