### PR TITLE
Quick and dirty approach to "Step might fail"

### DIFF
--- a/core/src/main/scala/cilib/Crossover.scala
+++ b/core/src/main/scala/cilib/Crossover.scala
@@ -16,15 +16,15 @@ object Crossover {
     parents => {
       def norm(x: Double, sum: Double) = 5.0 * (x / sum) - 1
 
-      for {
+      val offspring = for {
         coef <- Dist.stdUniform.replicateM(4)
         s = coef.sum
-        scaled = coef
-          .map(norm(_, s))
-          .toNel
-          .getOrElse(sys.error("Impossible - this is a safe usage as coef is always length 4"))
-        offspring = parents.zip(scaled).map(t => t._2 *: t._1).foldLeft1(_ + _)
-      } yield NonEmptyList(offspring)
+        scaled = coef.map(norm(_, s)).toNel
+      } yield scaled match {
+        case None => "Impossible - this is a safe usage as coef is always length 4".left
+        case Some(s) => NonEmptyList(parents.zip(s).map(t => t._2 *: t._1).foldLeft1(_ + _)).right
+      }
+      Step.mightFail.pointR(offspring)
     }
 
   def pcx(sigma1: Double, sigma2: Double): Crossover[Double] =
@@ -47,7 +47,7 @@ object Crossover {
 
       val distance = if (k > 2) dd / (k - 1) else 0.0
 
-      for {
+      Step.pointR(for {
         s1 <- Dist.gaussian(0.0, sigma1)
         s2 <- Dist.gaussian(0.0, sigma2)
       } yield {
@@ -55,7 +55,7 @@ object Crossover {
         NonEmptyList(e_eta.tail.foldLeft(offspring) { (c, e) =>
           c + (s2 *: (distance *: e))
         })
-      }
+      })
     }
 
   def undx(sigma1: Double, sigma2: Double): Crossover[Double] =
@@ -64,12 +64,14 @@ object Crossover {
       val bounds = parents.head.boundary
 
       // calculate mean of parents except main parents
-      val g = Algebra.meanVector(
-        parents.init.toNel.getOrElse(sys.error("UNDX requires at least 3 parents")))
+      val mean = parents.init.toNel match {
+        case Some(ps) if ps.length >= 3 => Algebra.meanVector(ps).right
+        case _ => "UNDX requires at least 3 parents".left
+      }
 
       // basis vectors defined by parents
       val initZeta = List[Position[Double]]()
-      val zeta = parents.init.foldLeft(initZeta) { (z, p) =>
+      val zeta = mean.map { g => parents.init.foldLeft(initZeta) { (z, p) =>
         val d = p - g
 
         if (d.isZero) z
@@ -80,27 +82,34 @@ object Crossover {
           if (e.isZero) z
           else z :+ (dbar *: e.normalize)
         }
-      }
+      }}
 
-      val dd = (parents.last - g).magnitude
 
       // create the remaining basis vectors
-      val initEta = NonEmptyList(parents.last - g)
-      positiveInt(n - zeta.length) { value =>
-        val reta = Position.createPositions(bounds, value) //n - zeta.length)
-        val eta = reta.map(r => Algebra.orthonormalize(initEta :::> r.toIList))
+      val basis = for {
+        g  <- mean
+        z  <- zeta
+        dd  = (parents.last - g).magnitude
+      } yield {
+        val initEta = NonEmptyList(parents.last - g)
 
-        // construct the offspring
-        for {
-          s1 <- Dist.gaussian(0.0, sigma1)
-          s2 <- Dist.gaussian(0.0, sigma2 / sqrt(n.toDouble))
-          e_eta <- eta
-        } yield {
-          val vars = zeta.foldLeft(g)((vr, z) => vr + (s1 *: z))
-          val offspring = e_eta.foldLeft(vars)((vr, e) => vr + ((dd * s2) *: e))
+        positiveInt(n - z.length) { value =>
+          val reta = Position.createPositions(bounds, value) //n - zeta.length)
+          val eta = reta.map(r => Algebra.orthonormalize(initEta :::> r.toIList))
 
-          NonEmptyList(offspring)
+          // construct the offspring
+          for {
+            s1 <- Dist.gaussian(0.0, sigma1)
+            s2 <- Dist.gaussian(0.0, sigma2 / sqrt(n.toDouble))
+            e_eta <- eta
+          } yield {
+            val vars = z.foldLeft(g)((vr, zi) => vr + (s1 *: zi))
+            val offspring = e_eta.foldLeft(vars)((vr, e) => vr + ((dd * s2) *: e))
+
+            NonEmptyList(offspring)
+          }
         }
       }
+      Step.mightFail.pointR(basis.sequenceU)
     }
 }

--- a/core/src/main/scala/cilib/Eval.scala
+++ b/core/src/main/scala/cilib/Eval.scala
@@ -1,9 +1,10 @@
 package cilib
 
-import scalaz.NonEmptyList
+import scalaz.{NonEmptyList,\/}
+import scalaz.Scalaz._
 
 trait Input[F[_]] {
-  def toInput[A](a: NonEmptyList[A]): F[A]
+  def toInput[A](a: NonEmptyList[A]): String \/ F[A]
 }
 
 sealed abstract class Eval[F[_], A] {
@@ -11,17 +12,18 @@ sealed abstract class Eval[F[_], A] {
 
   val F: Input[F]
 
-  def run: F[A] => Double
+  def run: F[A] => String \/ Double
 
-  def eval: RVar[NonEmptyList[A] => Objective[A]] =
-    RVar.point { (fa: NonEmptyList[A]) =>
+  def eval: RVar[NonEmptyList[A] => String \/ Objective[A]] =
+    RVar.point { (fa: NonEmptyList[A]) => F.toInput(fa).flatMap { v =>
       this match {
-        case Unconstrained(f, _) => Single(Feasible(f(F.toInput(fa))), List.empty)
+        case Unconstrained(f, _) => f(v).map(fv => Single(Feasible(fv), List.empty))
         case Constrained(f, cs, _) =>
           cs.filter(c => !Constraint.satisfies(c, fa)) match {
-            case Nil => Single(Feasible(f(F.toInput(fa))), List.empty)
-            case xs  => Single(Infeasible(f(F.toInput(fa)), xs.length), xs)
+            case Nil => f(v).map(fv => Single(Feasible(fv), List.empty))
+            case xs  => f(v).map(fv => Single(Infeasible(fv, xs.length), xs))
           }
+        }
       }
     }
 
@@ -33,34 +35,42 @@ sealed abstract class Eval[F[_], A] {
 }
 
 object Eval {
-  private final case class Unconstrained[F[_], A](run: F[A] => Double, F: Input[F])
+  private final case class Unconstrained[F[_], A](run: F[A] => String \/ Double, F: Input[F])
       extends Eval[F, A]
-  private final case class Constrained[F[_], A](run: F[A] => Double,
+  private final case class Constrained[F[_], A](run: F[A] => String \/ Double,
                                                 cs: List[Constraint[A]],
                                                 F: Input[F])
       extends Eval[F, A]
 
   def unconstrained[F[_]: Input, A](f: F[A] => Double)(implicit F: Input[F]): Eval[F, A] =
-    Unconstrained(f, F)
+    Unconstrained(f.map(_.right), F)
 
   def constrained[F[_]: Input, A](f: F[A] => Double, cs: List[Constraint[A]])(
       implicit F: Input[F]): Eval[F, A] =
-    Constrained(f, cs, F)
+    Constrained(f.map(_.right), cs, F)
+
+  object mightFail {
+    def unconstrained[F[_]: Input, A](f: F[A] => String \/ Double)(implicit F: Input[F]): Eval[F, A] =
+      Unconstrained(f, F)
+    def constrained[F[_]: Input, A](f: F[A] => String \/ Double, cs: List[Constraint[A]])(
+        implicit F: Input[F]): Eval[F, A] =
+      Constrained(f, cs, F)
+  }
 }
 
 trait EvalInstances {
   import scalaz.{ICons, NonEmptyList}
 
   implicit val nelInput: Input[NonEmptyList] = new Input[NonEmptyList] {
-    def toInput[A](a: NonEmptyList[A]): NonEmptyList[A] = a
+    def toInput[A](a: NonEmptyList[A]): String \/ NonEmptyList[A] = a.right
   }
 
   implicit val pairInput: Input[Lambda[x => (x, x)]] =
     new Input[Lambda[x => (x, x)]] {
-      def toInput[A](a: NonEmptyList[A]): (A, A) =
+      def toInput[A](a: NonEmptyList[A]): String \/ (A, A) =
         a.list match {
-          case ICons(a, ICons(b, _)) => (a, b)
-          case _                     => sys.error("error producing a pair")
+          case ICons(a, ICons(b, _)) => (a, b).right
+          case _                     => "Error producing a pair".left
         }
     }
 }

--- a/core/src/main/scala/cilib/Position.scala
+++ b/core/src/main/scala/cilib/Position.scala
@@ -164,16 +164,16 @@ object Position {
         }
     }
 
-  def eval[F[_], A](e: RVar[NonEmptyList[A] => Objective[A]], pos: Position[A]): RVar[Position[A]] =
+  def eval[F[_], A](e: RVar[NonEmptyList[A] => String \/ Objective[A]], pos: Position[A]): RVar[String \/ Position[A]] =
     pos match {
       case Point(x, b) =>
         e.map(f => {
-          val s: Objective[A] = f.apply(x)
-          Solution(x, b, s)
+          val s: String \/ Objective[A] = f.apply(x)
+          s.map(Solution(x, b, _))
         })
 
       case x @ Solution(_, _, _) =>
-        RVar.point(x)
+        RVar.point(x.right)
     }
 
   /*private[cilib]*/

--- a/core/src/main/scala/cilib/Position.scala
+++ b/core/src/main/scala/cilib/Position.scala
@@ -164,7 +164,8 @@ object Position {
         }
     }
 
-  def eval[F[_], A](e: RVar[NonEmptyList[A] => String \/ Objective[A]], pos: Position[A]): RVar[String \/ Position[A]] =
+  def eval[F[_], A](e: RVar[NonEmptyList[A] => String \/ Objective[A]],
+                    pos: Position[A]): RVar[String \/ Position[A]] =
     pos match {
       case Point(x, b) =>
         e.map(f => {

--- a/core/src/main/scala/cilib/Step.scala
+++ b/core/src/main/scala/cilib/Step.scala
@@ -28,10 +28,9 @@ final case class Step[A, B] private (run: Environment[A] => RVar[String \/ B]) {
   def flatMap[C](f: B => Step[A, C]): Step[A, C] =
     Step { e =>
       run(e).flatMap(_.map(f(_).run(e)).sequence.map(_ match {
-          case -\/(l) => l.left
-          case \/-(r) => r
-        })
-      )
+        case -\/(l) => l.left
+        case \/-(r) => r
+      }))
     }
 }
 
@@ -61,9 +60,8 @@ object Step {
     Step(env => Position.eval(env.eval, pos))
 
   object mightFail {
-    def withCompare[A, B](a: Comparison => String \/ B): Step[A, B] = {
+    def withCompare[A, B](a: Comparison => String \/ B): Step[A, B] =
       Step(env => RVar.point(a.apply(env.cmp)))
-    }
     def point[A, B](b: String \/ B): Step[A, B] =
       Step(_ => RVar.point(b))
     def pointR[A, B](a: RVar[String \/ B]): Step[A, B] =

--- a/core/src/main/scala/cilib/package.scala
+++ b/core/src/main/scala/cilib/package.scala
@@ -16,7 +16,7 @@ package object cilib extends EvalInstances {
   type RandSelection[A] = NonEmptyList[A] => RVar[List[A]]
   type RandIndexSelection[A] = (NonEmptyList[A], A) => RVar[List[A]]
 
-  type Crossover[A] = NonEmptyList[Position[A]] => Step[A,NonEmptyList[Position[A]]]
+  type Crossover[A] = NonEmptyList[Position[A]] => Step[A, NonEmptyList[Position[A]]]
 
   // Find a better home for this - should this even exist? it is unlawful
   implicit object DoubleMonoid extends Monoid[Double] {

--- a/core/src/main/scala/cilib/package.scala
+++ b/core/src/main/scala/cilib/package.scala
@@ -16,7 +16,7 @@ package object cilib extends EvalInstances {
   type RandSelection[A] = NonEmptyList[A] => RVar[List[A]]
   type RandIndexSelection[A] = (NonEmptyList[A], A) => RVar[List[A]]
 
-  type Crossover[A] = NonEmptyList[Position[A]] => RVar[NonEmptyList[Position[A]]]
+  type Crossover[A] = NonEmptyList[Position[A]] => Step[A,NonEmptyList[Position[A]]]
 
   // Find a better home for this - should this even exist? it is unlawful
   implicit object DoubleMonoid extends Monoid[Double] {

--- a/docs/src/main/tut/usage/gbestpso.md
+++ b/docs/src/main/tut/usage/gbestpso.md
@@ -114,7 +114,7 @@ have been performed
 val rng = RNG.fromTime // Seed the RNG with the current time of the computer
 
 val result = Runner.repeat(1000, iter, swarm).run(env)
-val positions = result.map(_.map(x => Lenses._position.get(x)))
+val positions = result.map(_.map(_.map(x => Lenses._position.get(x))))
 
 positions.run(rng)._2
 ```

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -33,7 +33,7 @@ object GBestPSO extends SafeApp {
   // Our IO[Unit] that runs the algorithm, at the end of the world
   override val runc: IO[Unit] = {
     val result = Runner.repeat(1000, iter, swarm).run(env).run(RNG.fromTime)
-    val positions = result._2.map(x => Lenses._position.get(x))
+    val positions = result._2.map(_.map(x => Lenses._position.get(x)))
 
     putStrLn(positions.toString)
   }

--- a/example/src/main/scala/cilib/example/Heterogeneous.scala
+++ b/example/src/main/scala/cilib/example/Heterogeneous.scala
@@ -148,9 +148,11 @@ object HPSO extends SafeApp {
     .run(RNG.fromTime)
 
   override val runc: IO[Unit] =
-    putStrLn { finalResult._2 match {
-      case -\/(error) => error
-      case \/-(result) => behaviourProfile(result._1._1, result._2).toString
-    }}
+    putStrLn {
+      finalResult._2 match {
+        case -\/(error)  => error
+        case \/-(result) => behaviourProfile(result._1._1, result._2).toString
+      }
+    }
 
 }

--- a/example/src/main/scala/cilib/example/Heterogeneous.scala
+++ b/example/src/main/scala/cilib/example/Heterogeneous.scala
@@ -148,6 +148,9 @@ object HPSO extends SafeApp {
     .run(RNG.fromTime)
 
   override val runc: IO[Unit] =
-    putStrLn(behaviourProfile(finalResult._2._1._1, finalResult._2._2).toString)
+    putStrLn { finalResult._2 match {
+      case -\/(error) => error
+      case \/-(result) => behaviourProfile(result._1._1, result._2).toString
+    }}
 
 }

--- a/example/src/main/scala/cilib/example/VonNeumannPSO.scala
+++ b/example/src/main/scala/cilib/example/VonNeumannPSO.scala
@@ -33,7 +33,7 @@ object VonNeumannPSO extends SafeApp {
   // Our IO[Unit] that runs the algorithm, at the end of the world
   override val runc: IO[Unit] = {
     val result = Runner.repeat(1000, iter, swarm).run(env).run(RNG.fromTime)
-    val positions = result._2.map(x => Lenses._position.get(x))
+    val positions = result._2.map(_.map(x => Lenses._position.get(x)))
 
     putStrLn(positions.toString)
   }

--- a/pso/src/main/scala/cilib/pso/Guide.scala
+++ b/pso/src/main/scala/cilib/pso/Guide.scala
@@ -20,7 +20,8 @@ object Guide {
       val fittest = selected
         .map(e => M._memory.get(e.state))
         .reduceLeftOption((a, c) => Comparison.compare(a, c).apply(o))
-      fittest.toRightDisjunction("Impossible: reduce on entity memory worked on empty memory member")
+      fittest.toRightDisjunction(
+        "Impossible: reduce on entity memory worked on empty memory member")
     })
   }
 
@@ -54,12 +55,12 @@ object Guide {
       val col = collection.list.filter(_ != x).toNel.toRightDisjunction("No distinct elements")
 
       for {
-        xs       <- Step.mightFail.point(col)
-        chosen   <- Step.pointR(RVar.sample(3, xs).run)
-        xover     = Crossover.nmpc
-        parents   = chosen.map(c => NonEmptyList.nel(x.pos, c.map(_.pos).toIList))
+        xs <- Step.mightFail.point(col)
+        chosen <- Step.pointR(RVar.sample(3, xs).run)
+        xover = Crossover.nmpc
+        parents = chosen.map(c => NonEmptyList.nel(x.pos, c.map(_.pos).toIList))
         children <- parents.traverse(xover).map(_.getOrElse(NonEmptyList(x.pos)))
-        probs    <- Step.pointR(x.pos.traverse(_ => Dist.stdUniform))
+        probs <- Step.pointR(x.pos.traverse(_ => Dist.stdUniform))
       } yield {
         val zipped = x.pos.zip(children.head).zip(probs)
         zipped.map { case ((xi, ci), pi) => if (pi < prob) ci else xi }

--- a/tests/src/test/scala/cilib/PSOTests.scala
+++ b/tests/src/test/scala/cilib/PSOTests.scala
@@ -43,9 +43,9 @@ object PSOTests extends Properties("QPSO") {
         cilib.pso.PSO.quantum(p, RVar.point(10.0), (a,b) => Dist.uniform(spire.math.Interval(a,b)))
           .run(env).run(RNG.init(seed))
 
-      val vectorLength = math.sqrt(result.pos.foldLeft(0.0)((a,c) => a + c*c))
+      val vectorLength = result.map(r => math.sqrt(r.pos.foldLeft(0.0)((a,c) => a + c*c)))
 
-      vectorLength <= 10.0
+      vectorLength.all(_ <= 10.0)
     }
   }
 }

--- a/tests/src/test/scala/cilib/StepTest.scala
+++ b/tests/src/test/scala/cilib/StepTest.scala
@@ -16,8 +16,8 @@ object StepTest extends Spec("Step") {
     eval = Eval.unconstrained((l: NonEmptyList[Int]) => l.list.foldLeft(0.0)(_ + _)).eval,
     bounds = NonEmptyList(Interval(-5.12,5.12)))
 
-  implicit def stepEqual = scalaz.Equal[Int].contramap((_: Step[Int,Int]).run.apply(env).run(rng)._2)
-  implicit def stepSEqual = scalaz.Equal[Int].contramap((_: StepS[Int,Int,Int]).run.apply(3).run.apply(env).run(rng)._2._2)
+  implicit def stepEqual = scalaz.Equal[Int].contramap((_: Step[Int,Int]).run.apply(env).run(rng)._2.toOption.get)
+  implicit def stepSEqual = scalaz.Equal[Int].contramap((_: StepS[Int,Int,Int]).run.apply(3).run.apply(env).run(rng)._2.map(_._2).toOption.get)
 
   implicit def arbStep: Arbitrary[Step[Int,Int]] = Arbitrary {
     Arbitrary.arbitrary[Int].map(Step.point)


### PR DESCRIPTION
A `Step[?, B]` when evaluated now produces `String \/ B`

This encapsulates the logic that a `Step` might fail, e.g. a crossover operation where not enough parents are present, or a function evaluation that is not defined at some point (read divide by zero), or an `Input` that is not the correct dimension.

For the most part `Step` usage remains the same. But now you can also do things like this:

```scala
def undx(sigma1: Double, sigma2: Double): Crossover[Double] =
  parents => {
    val n = parents.head.pos.length
    val bounds = parents.head.boundary

    // calculate mean of parents except main parents
    val mean = parents.init.toNel match {
      case Some(ps) if ps.length >= 3 => Algebra.meanVector(ps).right
      case _                          => "UNDX requires at least 3 parents".left
    }

    Step.mightFail.point(mean)
}
```

or

```scala
Step.mightFail.pointR { 
  RVar.choose(NonEmptyList(0, 1)).map(_ match { 
    case 0     => "Oh no, we've got a problem here!".left
    case _ @ x => x.right
  })
```

The motivation came about in an effort to remove (some) `sys.error` calls in the library as well as cleanly fail when running certain benchmark functions.

There is undoubtedly a cleaner approach to do this, @filinep suggested Writer monad? Comments welcome.