### PR TITLE
Add badges to show versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/cirg-up/cilib.svg?branch=series%2F2.0.x)](https://travis-ci.org/cirg-up/cilib)
 [![Join the chat at https://gitter.im/cirg-up/cilib](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cirg-up/cilib?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Maven Central](https://img.shields.io/maven-central/v/net.cilib/cilib-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/net.cilib/cilib-core_2.12)
+[![Javadocs](https://javadoc.io/badge/net.cilib/cilib-core_2.12.svg)](https://javadoc.io/doc/net.cilib/cilib-core_2.12)
 
 CIlib is a library of various computational intelligence
 algorithms. The goal of the project is to create a library that can be used


### PR DESCRIPTION
Additional badges in the README to show what the current version is. This at least prevents the need to continually update the README file with the new version numbers, as releases happen.