### PR TITLE
Rename point -> pure and pointR -> liftR

### DIFF
--- a/core/src/main/scala/cilib/Eval.scala
+++ b/core/src/main/scala/cilib/Eval.scala
@@ -14,7 +14,7 @@ sealed abstract class Eval[F[_], A] {
   def run: F[A] => Double
 
   def eval: RVar[NonEmptyList[A] => Objective[A]] =
-    RVar.point { (fa: NonEmptyList[A]) =>
+    RVar.pure { (fa: NonEmptyList[A]) =>
       this match {
         case Unconstrained(f, _) => Single(Feasible(f(F.toInput(fa))), List.empty)
         case Constrained(f, cs, _) =>

--- a/core/src/main/scala/cilib/Fitness.scala
+++ b/core/src/main/scala/cilib/Fitness.scala
@@ -79,7 +79,7 @@ object Comparison {
 
   def fittest[F[_], A](a: F[A], b: F[A])(implicit F: Fitness[F, A]): Step[A, F[A]] =
     Step.withCompareR(comp =>
-      RVar.point {
+      RVar.pure {
         if (fitter(a, b).apply(comp)) a else b
     })
 

--- a/core/src/main/scala/cilib/MetricSpace.scala
+++ b/core/src/main/scala/cilib/MetricSpace.scala
@@ -90,7 +90,12 @@ object MetricSpace {
         x.toList.zip(y.toList).filter { case (ai, bi) => ai != bi }.size
     }
 
+  @deprecated("This method has been deprecated, use pure instead, it is technically better",
+              "2.0.2")
   def point[A, B](a: B): MetricSpace[A, B] =
+    pure(a)
+
+  def pure[A, B](a: B): MetricSpace[A, B] =
     new MetricSpace[A, B] {
       def dist(x: A, y: A) = a
     }
@@ -118,7 +123,7 @@ object MetricSpace {
   implicit def metricSpaceMonad[A]: Monad[MetricSpace[A, ?]] =
     new Monad[MetricSpace[A, ?]] {
       def point[B](a: => B): MetricSpace[A, B] =
-        MetricSpace.point[A, B](a)
+        MetricSpace.pure[A, B](a)
 
       def bind[B, C](fa: MetricSpace[A, B])(f: B => MetricSpace[A, C]): MetricSpace[A, C] =
         fa.flatMap(f)

--- a/core/src/main/scala/cilib/Position.scala
+++ b/core/src/main/scala/cilib/Position.scala
@@ -173,7 +173,7 @@ object Position {
         })
 
       case x @ Solution(_, _, _) =>
-        RVar.point(x)
+        RVar.pure(x)
     }
 
   /*private[cilib]*/

--- a/de/src/main/scala/DE.scala
+++ b/de/src/main/scala/DE.scala
@@ -26,7 +26,7 @@ object DE {
         for {
           evaluated <- Step.eval((a: Position[A]) => a)(x)
           trial <- basicMutation(Numeric[A].fromDouble(p_m), targetSelection, y, collection, x)
-          pivots <- Step.pointR(z(p_r, evaluated.pos))
+          pivots <- Step.liftR(z(p_r, evaluated.pos))
           offspring = crossover(x, trial, pivots)
           evaluatedOffspring <- Step.eval((a: Position[A]) => a)(offspring)
           fittest <- Comparison.fittest(evaluated, evaluatedOffspring)
@@ -52,7 +52,7 @@ object DE {
       filtered.flatMap(x =>
         x.toNel match {
           case Some(l) =>
-            Step.pointR(
+            Step.liftR(
               RVar
                 .shuffle(l)
                 .map(
@@ -62,7 +62,7 @@ object DE {
                       .map(z => z._1.pos - z._2.pos))
             )
           case None =>
-            Step.point(List.empty)
+            Step.pure(List.empty)
       })
 
     for {
@@ -88,7 +88,7 @@ object DE {
       .flatMap(j =>
         parent.toNel.zipWithIndex.traverse {
           case (_, i) =>
-            if (i == j) RVar.point(true)
+            if (i == j) RVar.pure(true)
             else Dist.stdUniform.map(_ < p_r)
       })
 
@@ -119,7 +119,7 @@ object DE {
   // Selections
   def randSelection[S, A](
       collection: NonEmptyList[Entity[S, A]]): Step[A, (Entity[S, A], Position[A])] =
-    Step.pointR(RVar.choose(collection).map(x => (x, x.pos)))
+    Step.liftR(RVar.choose(collection).map(x => (x, x.pos)))
 
   def bestSelection[S, A](
       collection: NonEmptyList[Entity[S, A]]): Step[A, (Entity[S, A], Position[A])] =

--- a/eda/src/main/scala/EDA.scala
+++ b/eda/src/main/scala/EDA.scala
@@ -13,9 +13,9 @@ object EDA {
   ): NonEmptyList[Entity[S, A]] => Step[A, NonEmptyList[Entity[S, A]]] =
     collection =>
       for {
-        selected <- Step.pointR(selection(collection))
-        newModel <- Step.pointR(generateModel(collection))
-        generated <- Step.pointR(collection.traverse(x => sample(newModel, x)))
+        selected <- Step.liftR(selection(collection))
+        newModel <- Step.liftR(generateModel(collection))
+        generated <- Step.liftR(collection.traverse(x => sample(newModel, x)))
         evaluated <- generated.traverse(x => Step.eval((v: Position[A]) => v)(x))
       } yield evaluated
 
@@ -39,8 +39,8 @@ object EDA {
   //         .replicateM(entity.pos.length)
   //         .map(l =>
   //           Entity((), Position(l.toNel.getOrElse(sys.error("asdsad")), entity.pos.boundary))),
-  //     selection = (l: NonEmptyList[Entity[Unit, Double]]) => RVar.point(l),
-  //     generateModel = (_: NonEmptyList[Entity[Unit, Double]]) => RVar.point(Dist.stdUniform)
+  //     selection = (l: NonEmptyList[Entity[Unit, Double]]) => RVar.pure(l),
+  //     generateModel = (_: NonEmptyList[Entity[Unit, Double]]) => RVar.pure(Dist.stdUniform)
   //   )
 }
 

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -44,7 +44,7 @@ object GAExample extends SafeApp {
         p.traverse(z =>
           for {
             za <- Dist.stdUniform.map(_ < p_m)
-            zb <- if (za) Dist.stdNormal.flatMap(Dist.gaussian(0, _)).map(_ * z) else RVar.point(z)
+            zb <- if (za) Dist.stdNormal.flatMap(Dist.gaussian(0, _)).map(_ * z) else RVar.pure(z)
           } yield zb))(x)
     })
 

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -39,7 +39,7 @@ object GBestPSO extends SafeApp {
                             swarm,
                             Algorithm("gbestPSO", iter),
                             problemStream,
-                            (x: NonEmptyList[Particle[Mem[Double], Double]]) => RVar.point(x))
+                            (x: NonEmptyList[Particle[Mem[Double], Double]]) => RVar.pure(x))
 
     putStrLn(t.runLast.unsafePerformSync.toString)
   }

--- a/example/src/main/scala/cilib/example/Heterogeneous.scala
+++ b/example/src/main/scala/cilib/example/Heterogeneous.scala
@@ -107,7 +107,7 @@ object HPSO extends SafeApp {
 
   val population =
     StepS
-      .pointR[Double, BehaviourPool, NonEmptyList[Particle[PState, Double]]](
+      .liftR[Double, BehaviourPool, NonEmptyList[Particle[PState, Double]]](
         Position.createCollection(particleBuilder)(bounds, 10))
       //.liftStepS[Double,BehaviourPool]
       .flatMap(assignRandom)

--- a/example/src/main/scala/cilib/example/QuantumPSO.scala
+++ b/example/src/main/scala/cilib/example/QuantumPSO.scala
@@ -50,7 +50,7 @@ object QuantumPSO extends SafeApp {
     }
 
   def evalParticleWithPenalty[S](entity: Particle[S,Double]) =
-    Entity.eval[S,Double](x => x)(entity).flatMap(e => Step.withCompare(o => RVar.point {
+    Entity.eval[S,Double](x => x)(entity).flatMap(e => Step.withCompare(o => RVar.pure {
       penalize(o.opt)(e)
     }))
 
@@ -99,7 +99,7 @@ object QuantumPSO extends SafeApp {
   // Usage
   val domain = spire.math.Interval(0.0, 100.0)^2
   //val r = Iteration.sync(quantumPSO[QuantumState,List](0.729844, 1.496180, 1.496180, Guide.pbest, Guide.gbest))
-  val qpso = Iteration.sync(quantumPSO[QuantumState](0.729844, 1.496180, 1.496180, Guide.pbest, Guide.dominance(Selection.star), (_,_) => RVar.point(50.0)))
+  val qpso = Iteration.sync(quantumPSO[QuantumState](0.729844, 1.496180, 1.496180, Guide.pbest, Guide.dominance(Selection.star), (_,_) => RVar.pure(50.0)))
   val qpsoDist = Iteration.sync(quantumPSO[QuantumState](0.729844, 1.496180, 1.496180, Guide.pbest, Guide.gbest, (_,_) => Dist.cauchy(0.0, 10.0)))
 
   def swarm = Position.createCollection(
@@ -179,14 +179,14 @@ object QuantumPSO extends SafeApp {
     def iteration(
       swarm: List[cilib.Entity[cilib.example.QuantumPSO.QuantumState,Double]]
     ): Step[Double,List[cilib.Entity[cilib.example.QuantumPSO.QuantumState,Double]]] = {
-      //swarm.toNel.cata(nel => qpso.run(nel.list).run.map(_.map(penalize(Max))), Step.point(List.empty))
+      //swarm.toNel.cata(nel => qpso.run(nel.list).run.map(_.map(penalize(Max))), Step.pure(List.empty))
       qpso.run(swarm)
     }
 
     import scalaz.StateT
     def mpb(heightSeverity: Double, widthSeverity: Double): StateT[RVar, (NonEmptyList[Problems.PeakCone],List[cilib.Entity[cilib.example.QuantumPSO.QuantumState,Double]]), Eval[NonEmptyList,Double]] =
       StateT { case (peaks, pop) => {
-        val newPeaks: RVar[NonEmptyList[Problems.PeakCone]] = RVar.point(peaks)//.traverse(_.update(heightSeverity, widthSeverity))
+        val newPeaks: RVar[NonEmptyList[Problems.PeakCone]] = RVar.pure(peaks)//.traverse(_.update(heightSeverity, widthSeverity))
         newPeaks.map(np => ((np, pop), Problems.peakEval(np).constrain(EnvConstraints.centerEllipse)))
       }}
   }

--- a/exec/src/main/scala/cilib/MonadStep.scala
+++ b/exec/src/main/scala/cilib/MonadStep.scala
@@ -4,5 +4,10 @@ package exec
 import scalaz.Monad
 
 abstract class MonadStep[M[_]: Monad] {
-  def pointR[A](r: RVar[A]): M[A]
+  @deprecated("This method has been deprecated, use liftR instead, it is technically more accurate",
+              "2.0.2")
+  def pointR[A](r: RVar[A]): M[A] =
+    liftR(r)
+
+  def liftR[A](r: RVar[A]): M[A]
 }

--- a/exec/src/main/scala/cilib/Runner.scala
+++ b/exec/src/main/scala/cilib/Runner.scala
@@ -27,7 +27,7 @@ object Runner {
 
   def repeat[M[_]: Monad, F[_], A](n: Int, alg: Kleisli[M, F[A], F[A]], collection: RVar[F[A]])(
       implicit M: MonadStep[M]): M[F[A]] =
-    M.pointR(collection)
+    M.liftR(collection)
       .flatMap(coll =>
         (1 to n).toStream.foldLeftM[M, F[A]](coll) { (a, _) =>
           alg.run(a)
@@ -39,7 +39,7 @@ object Runner {
       rng: RNG
   ): Process[Task, Problem[A]] = {
     val (_, e) = eval.run(rng)
-    Process.constant(Problem(name, Unchanged, RVar.point(e)))
+    Process.constant(Problem(name, Unchanged, RVar.pure(e)))
   }
 
   def problem[S, A](name: String Refined NonEmpty,

--- a/exec/src/main/scala/cilib/package.scala
+++ b/exec/src/main/scala/cilib/package.scala
@@ -4,13 +4,13 @@ package object exec {
 
   implicit def StepMonadStep[A] =
     new MonadStep[Step[A, ?]] {
-      def pointR[B](r: RVar[B]): Step[A, B] =
-        Step.pointR(r)
+      def liftR[B](r: RVar[B]): Step[A, B] =
+        Step.liftR(r)
     }
 
   implicit def StepSMonadStep[S, A] =
     new MonadStep[StepS[S, A, ?]] {
-      def pointR[B](r: RVar[B]): StepS[S, A, B] =
-        StepS.pointR(r)
+      def liftR[B](r: RVar[B]): StepS[S, A, B] =
+        StepS.liftR(r)
     }
 }

--- a/ga/src/main/scala/cilib/ga/GA.scala
+++ b/ga/src/main/scala/cilib/ga/GA.scala
@@ -18,11 +18,11 @@ object GA {
     collection =>
       x =>
         for {
-          parents <- Step.pointR(parentSelection(collection))
-          r <- Step.pointR(Dist.stdUniform.map(_ < p_c))
-          crossed <- if (r) Step.pointR[Double, List[Individual[S]]](crossover(parents))
-          else Step.point[Double, List[Individual[S]]](parents)
-          mutated <- Step.pointR[Double, List[Individual[S]]](mutation(crossed))
+          parents <- Step.liftR(parentSelection(collection))
+          r <- Step.liftR(Dist.stdUniform.map(_ < p_c))
+          crossed <- if (r) Step.liftR[Double, List[Individual[S]]](crossover(parents))
+          else Step.pure[Double, List[Individual[S]]](parents)
+          mutated <- Step.liftR[Double, List[Individual[S]]](mutation(crossed))
           evaluated <- mutated.traverse(x => Step.eval((v: Position[Double]) => v)(x))
         } yield evaluated
 
@@ -38,6 +38,6 @@ object GA {
       parents.traverse(parent =>
         Lenses._position.modifyF((p: Position[Double]) => p.traverse(distribution))(parent))
 
-    GA.ga(1.0, parentSelection, RVar.point(_), mutation(distribution))
+    GA.ga(1.0, parentSelection, RVar.pure(_), mutation(distribution))
   }
 }

--- a/pso/src/main/scala/cilib/pso/Defaults.scala
+++ b/pso/src/main/scala/cilib/pso/Defaults.scala
@@ -97,7 +97,7 @@ object Defaults {
           for {
             gbest <- hoist.liftMU(g(collection, x))
             cog <- hoist.liftMU(cognitive(collection, x))
-            isBest <- hoist.liftMU(Step.point[Double, Boolean](x.pos eq gbest))
+            isBest <- hoist.liftMU(Step.pure[Double, Boolean](x.pos eq gbest))
             s <- S.get
             v <- hoist.liftMU(
               if (isBest) gcVelocity(x, gbest, w, s)
@@ -196,7 +196,7 @@ object Defaults {
       nbest: Position[Double],
       g: Double
     )(implicit M:Memory[S,Double], MO: Module[Position[Double],Double], F:Field[Double]): Step[Double,Position[Double]] =
-      Step.pointR(for {
+      Step.liftR(for {
         c1 <- Dist.stdUniform.replicateM(entity.pos.pos.size).map(Position.hack) // RVar[List[Double]]
         c2 <- Dist.stdUniform.replicateM(entity.pos.pos.size).map(Position.hack)
         (p_i: Position[Double]) = M._memory.get(entity.state).zip(c1).map(x => x._1 * x._2)

--- a/pso/src/main/scala/cilib/pso/Heterogeneous.scala
+++ b/pso/src/main/scala/cilib/pso/Heterogeneous.scala
@@ -113,7 +113,7 @@ object Heterogeneous {
     xs =>
       for {
         pool <- M.get
-        collection <- StepS.pointR(xs.traverse { x =>
+        collection <- StepS.liftR(xs.traverse { x =>
           RVar.shuffle(pool).map { l =>
             User(x, l.head)
           }
@@ -137,7 +137,7 @@ object Heterogeneous {
         val M = MonadState[StepS[C, Pool[B], ?], Pool[B]]
         for {
           pool <- M.get
-          user <- StepS.pointR(RVar.shuffle(pool).map { l =>
+          user <- StepS.liftR(RVar.shuffle(pool).map { l =>
             User(x.user, l.head)
           })
         } yield user
@@ -150,7 +150,7 @@ object Heterogeneous {
         val M = MonadState[StepS[C, Pool[B], ?], Pool[B]]
         for {
           pool <- M.get
-          user <- StepS.pointR(RVar.shuffle(pool).map(_.toList.take(k)).map { bs =>
+          user <- StepS.liftR(RVar.shuffle(pool).map(_.toList.take(k)).map { bs =>
             {
               val tournament = bs.take(k) // ???? This is an error. Might as well just use head directly???
               val head = tournament.headOption.getOrElse(sys.error("Empty behaviour pool."))
@@ -217,8 +217,8 @@ object Heterogeneous {
 
         for {
           p1 <- S
-            .point(schedule(x))
-            .ifM(ifTrue = selector(collection)(x).zoom(pool), ifFalse = S.point(x))
+            .pure(schedule(x))
+            .ifM(ifTrue = selector(collection)(x).zoom(pool), ifFalse = S.pure(x))
           p2 <- useBehaviour(collection)(p1).zoom(params)
           newP <- updater(x)(p2).zoom(pool)
           _ <- MonadState[StepS[A, Pool[Behaviour[S, A, B]], ?], Pool[Behaviour[S, A, B]]]

--- a/tests/src/test/scala/cilib/MetricSpaceTests.scala
+++ b/tests/src/test/scala/cilib/MetricSpaceTests.scala
@@ -12,11 +12,11 @@ import spire.implicits._
 object MetricSpaceTest extends Spec("MetricSpace") {
 
   implicit def arbMetricSpace: Arbitrary[MetricSpace[Int,Int]] = Arbitrary {
-    Arbitrary.arbitrary[Int].map(x => MetricSpace.point[Int,Int](x))
+    Arbitrary.arbitrary[Int].map(x => MetricSpace.pure[Int,Int](x))
   }
 
   implicit def arbMetricSpaceFunc: Arbitrary[MetricSpace[Int, Int => Int]] = Arbitrary {
-    Arbitrary.arbitrary[Int => Int].map(MetricSpace.point[Int, Int => Int])
+    Arbitrary.arbitrary[Int => Int].map(MetricSpace.pure[Int, Int => Int])
   }
 
   implicit val doubleGen = Gen.choose(-100000000.0, 100000000.0)

--- a/tests/src/test/scala/cilib/PSOTests.scala
+++ b/tests/src/test/scala/cilib/PSOTests.scala
@@ -39,7 +39,7 @@ object PSOTests extends Properties("QPSO") {
         eval = Eval.unconstrained((x: NonEmptyList[Double]) => 0.0).eval)
 
       val (_, result) =
-        cilib.pso.PSO.quantum(p.pos, RVar.point(10.0), (a,b) => Dist.uniform(spire.math.Interval(a,b)))
+        cilib.pso.PSO.quantum(p.pos, RVar.pure(10.0), (a,b) => Dist.uniform(spire.math.Interval(a,b)))
           .run(env).run(RNG.init(seed))
 
       result match {

--- a/tests/src/test/scala/cilib/RVarTests.scala
+++ b/tests/src/test/scala/cilib/RVarTests.scala
@@ -13,11 +13,11 @@ object RVarTests extends Spec("RVar") {
   implicit def rngEqual = scalaz.Equal[Int].contramap((_: RVar[Int]).run(rng)._2)
 
   implicit def arbRVar: Arbitrary[RVar[Int]] = Arbitrary {
-    Arbitrary.arbitrary[Int].map(RVar.point(_))
+    Arbitrary.arbitrary[Int].map(RVar.pure(_))
   }
 
   implicit def arbRVarFunc: Arbitrary[RVar[Int => Int]] = Arbitrary {
-    Arbitrary.arbitrary[Int => Int].map(RVar.point(_))
+    Arbitrary.arbitrary[Int => Int].map(RVar.pure(_))
   }
 
   checkAll(equal.laws[RVar[Int]])

--- a/tests/src/test/scala/cilib/StepTest.scala
+++ b/tests/src/test/scala/cilib/StepTest.scala
@@ -16,11 +16,11 @@ object StepTest extends Spec("Step") {
   implicit def stepSEqual = scalaz.Equal[Int].contramap((_: StepS[Int,Int,Int]).run.apply(3).run(env).run(rng)._2.fold(l => 0, r => r._2))
 
   implicit def arbStep: Arbitrary[Step[Int,Int]] = Arbitrary {
-    Arbitrary.arbitrary[Int].map(Step.point)
+    Arbitrary.arbitrary[Int].map(Step.pure)
   }
 
   implicit def arbStepFunc: Arbitrary[Step[Int, Int => Int]] = Arbitrary {
-    Arbitrary.arbitrary[Int => Int].map(Step.point[Int, Int => Int])
+    Arbitrary.arbitrary[Int => Int].map(Step.pure[Int, Int => Int])
   }
 
   implicit def arbStepS: Arbitrary[StepS[Int, Int, Int]] = Arbitrary {


### PR DESCRIPTION
As within Haskell, `pure` is the preferred usage. It also makes a little
more sense as the provided value is placed into the monad context such
that the same value will be extracted later. Similarly, the same
argument can be made for the pointR -> liftR rename, as you are
lifting a random value (RVar) into another context.

Feedback on doing something similar for `StepS` and `pointS` would be
appreciated.