### PR TITLE
Algorithm stream, allowing for changes based on iteration number

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,3 @@ intelligence algorithms and uses several typeclasses such as `Functor` and
 * If you run into trouble, please open an issue
 * Come join in the discussion in `#cilib` on `FreeNode`, or join
   the [Gitter channel](https://gitter.im/cirg-up/cilib)
-
-CIlib is maintained by several individuals and supported by CIRG @ UP
-(Computational Intelligence Research Group @ University of Pretoria).

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -37,7 +37,7 @@ object GBestPSO extends SafeApp {
     val t = Runner.foldStep(env,
                             RNG.fromTime,
                             swarm,
-                            Runner.constantAlgorithm("gbestPSO", iter),
+                            Runner.staticAlgorithm("gbestPSO", iter),
                             problemStream,
                             (x: NonEmptyList[Particle[Mem[Double], Double]]) => RVar.pure(x))
 

--- a/exec/src/main/scala/cilib/Runner.scala
+++ b/exec/src/main/scala/cilib/Runner.scala
@@ -34,8 +34,8 @@ object Runner {
           alg.run(a)
       })
 
-  def constantAlgorithm[M[_]: Monad, F[_], A](name: String Refined NonEmpty,
-                                              a: Kleisli[M, F[A], F[A]]) =
+  def staticAlgorithm[M[_]: Monad, F[_], A](name: String Refined NonEmpty,
+                                            a: Kleisli[M, F[A], F[A]]) =
     Process.constant(Algorithm(name, a))
 
   def algorithm[M[_]: Monad, F[_]: Foldable1, A, B](

--- a/exec/src/main/scala/cilib/Runner.scala
+++ b/exec/src/main/scala/cilib/Runner.scala
@@ -40,17 +40,18 @@ object Runner {
 
   def algorithm[M[_]: Monad, F[_]: Foldable1, A, B](
       name: String Refined NonEmpty,
-      a: A,
+      config: A,
       f: A => Kleisli[M, F[B], F[B]],
       updater: (A, Int @@ Iteration) => A): Process[Nothing, Algorithm[Kleisli[M, F[B], F[B]]]] = {
 
     def go(current: A, iteration: Int): Process[Nothing, Algorithm[Kleisli[M, F[B], F[B]]]] = {
       val next = f(current)
 
-      Process.emit(Algorithm(name, next)) ++ go(updater(current, Tag[Int, Iteration](iteration)), iteration + 1)
+      Process.emit(Algorithm(name, next)) ++
+        go(updater(current, Tag[Int, Iteration](iteration)), iteration + 1)
     }
 
-    go(a, 1)
+    go(config, 1)
   }
 
   def staticProblem[S, A](

--- a/exec/src/main/scala/cilib/Runner.scala
+++ b/exec/src/main/scala/cilib/Runner.scala
@@ -24,6 +24,8 @@ final case class Progress[A] private (algorithm: String,
 
 object Runner {
 
+  trait Iteration
+
   def repeat[M[_]: Monad, F[_], A](n: Int, alg: Kleisli[M, F[A], F[A]], collection: RVar[F[A]])(
       implicit M: MonadStep[M]): M[F[A]] =
     M.liftR(collection)
@@ -35,6 +37,21 @@ object Runner {
   def constantAlgorithm[M[_]: Monad, F[_], A](name: String Refined NonEmpty,
                                               a: Kleisli[M, F[A], F[A]]) =
     Process.constant(Algorithm(name, a))
+
+  def algorithm[M[_]: Monad, F[_]: Foldable1, A, B](
+      name: String Refined NonEmpty,
+      a: A,
+      f: A => Kleisli[M, F[B], F[B]],
+      updater: (A, Int @@ Iteration) => A): Process[Nothing, Algorithm[Kleisli[M, F[B], F[B]]]] = {
+
+    def go(current: A, iteration: Int): Process[Nothing, Algorithm[Kleisli[M, F[B], F[B]]]] = {
+      val next = f(current)
+
+      Process.emit(Algorithm(name, next)) ++ go(updater(current, Tag[Int, Iteration](iteration)), iteration + 1)
+    }
+
+    go(a, 1)
+  }
 
   def staticProblem[S, A](
       name: String Refined NonEmpty,


### PR DESCRIPTION
The one feature required to complete the runner was the ability to
have the algorithm parameters vary over the course of the
execution. This patch introduces such a function that allows the user
to provide all the needed logic and produces a stream of algorithm
instances from the prodiced data.

Fixes #217