### PR TITLE
Limit sinks to Measurement[A] values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ sudo: false
 
 matrix:
   include:
-  - env: SBT_VERSION="1.0.4" COMMAND="clean test scalafmtCheck"
+  - env: SBT_VERSION="1.1.2" COMMAND="clean test scalafmtCheck"
     jdk: oraclejdk8
     scala: 2.11.11
-  - env: SBT_VERSION="1.0.4" COMMAND="clean test scalafmtCheck"
+  - env: SBT_VERSION="1.1.2" COMMAND="clean test scalafmtCheck"
     jdk: oraclejdk8
     scala: 2.12.4
-  - env: SBT_VERSION="1.0.4" COMMAND="clean test scalafmtCheck docs/makeSite"
+  - env: SBT_VERSION="1.1.2" COMMAND="clean test scalafmtCheck docs/makeSite"
     jdk: oraclejdk9
     scala: 2.12.4
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import sbt._
 import sbt.Keys._
 import sbtrelease.ReleaseStateTransformations._
 
-val scalazVersion     = "7.2.7"
+val scalazVersion     = "7.2.21"
 val scalazStreamVersion = "0.8.6a"
-val spireVersion      = "0.13.0"
+val spireVersion      = "0.14.1"
 val monocleVersion    = "1.3.2"
 val scalacheckVersion = "1.12.6"
 val avro4sVersion = "1.8.3"
@@ -176,7 +176,7 @@ lazy val core = project
       libraryDependencies ++= Seq(
         "org.scalaz" %% "scalaz-core" % scalazVersion,
         "org.scalaz" %% "scalaz-concurrent" % scalazVersion,
-        "org.spire-math" %% "spire" % spireVersion,
+        "org.typelevel" %% "spire" % spireVersion,
         "com.github.julien-truffaut" %% "monocle-core" % monocleVersion,
         "com.chuusai" %% "shapeless" % "2.3.2",
         "eu.timepit" %% "refined" % "0.8.5"

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtrelease.ReleaseStateTransformations._
 
 val scalazVersion     = "7.2.21"
 val scalazStreamVersion = "0.8.6a"
-val spireVersion      = "0.14.1"
+val spireVersion      = "0.13.0"
 val monocleVersion    = "1.3.2"
 val scalacheckVersion = "1.12.6"
 val avro4sVersion = "1.8.3"
@@ -176,7 +176,7 @@ lazy val core = project
       libraryDependencies ++= Seq(
         "org.scalaz" %% "scalaz-core" % scalazVersion,
         "org.scalaz" %% "scalaz-concurrent" % scalazVersion,
-        "org.typelevel" %% "spire" % spireVersion,
+        "org.spire-math" %% "spire" % spireVersion,
         "com.github.julien-truffaut" %% "monocle-core" % monocleVersion,
         "com.chuusai" %% "shapeless" % "2.3.2",
         "eu.timepit" %% "refined" % "0.8.5"

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -41,10 +41,6 @@ object GBestPSO extends SafeApp {
                             problemStream,
                             (x: NonEmptyList[Particle[Mem[Double], Double]]) => RVar.pure(x))
 
-    putStrLn(
-      t.take(1000)
-        .runLast
-        .unsafePerformSync
-        .toString)
+    putStrLn(t.take(1000).runLast.unsafePerformSync.toString)
   }
 }

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -41,10 +41,10 @@ object GBestPSO extends SafeApp {
                             problemStream,
                             (x: NonEmptyList[Particle[Mem[Double], Double]]) => RVar.pure(x))
 
-    putStrLn(t
-      .take(1000)
-      .runLast
-      .unsafePerformSync
-      .toString)
+    putStrLn(
+      t.take(1000)
+        .runLast
+        .unsafePerformSync
+        .toString)
   }
 }

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -30,7 +30,7 @@ object GBestPSO extends SafeApp {
     Position.createCollection(PSO.createParticle(x => Entity(Mem(x, x.zeroed), x)))(bounds, 20)
   val iter = Iteration.sync(gbestPSO)
 
-  val problemStream = Runner.staticProblem("spherical", env.eval, RNG.init(123L)).take(1000)
+  val problemStream = Runner.staticProblem("spherical", env.eval, RNG.init(123L))
 
   // Our IO[Unit] that runs the algorithm, at the end of the world
   override val runc: IO[Unit] = {
@@ -41,6 +41,10 @@ object GBestPSO extends SafeApp {
                             problemStream,
                             (x: NonEmptyList[Particle[Mem[Double], Double]]) => RVar.pure(x))
 
-    putStrLn(t.runLast.unsafePerformSync.toString)
+    putStrLn(t
+      .take(1000)
+      .runLast
+      .unsafePerformSync
+      .toString)
   }
 }

--- a/io/src/main/scala/csv.scala
+++ b/io/src/main/scala/csv.scala
@@ -1,12 +1,14 @@
 package cilib
 package io
 
-@annotation.implicitNotFound(
-  """Not all members of type ${A} have instances of EncodeCsv defined or in scope.
-It is recommended to examine the fields of ${A} and then to define
-an instance of EncodeCsv for the custom parameter type. The predefined
-known instances are for the following types: Boolean, Byte, Short,
-Int, Long, FLoat, Double, String, and Foldable[_] types such as List""")
+@annotation.implicitNotFound("""
+EncodeCsv derivation error for type: ${A}
+Not all members of the type have instances of EncodeCsv defined, or in
+scope. It is recommended to examine the fields of the type and then to
+define an instance of EncodeCsv for the any custom parameter type. The
+pre-defined, known, instances exist for the following types:
+Boolean, Byte, Short, Int, Long, FLoat, Double, String, Env, and
+Foldable[_] types such as List""")
 trait EncodeCsv[A] {
   def encode(a: A): List[String]
 }
@@ -30,6 +32,12 @@ object EncodeCsv {
 
   implicit def foldableEncodeCsv[F[_], A](implicit F: Foldable[F], A: EncodeCsv[A]) =
     EncodeCsv[F[A]](l => List(F.toList(l).flatMap(A.encode).mkString("[", ",", "]")))
+
+  implicit val envEncodeCsv =
+    EncodeCsv[cilib.exec.Env](_ match {
+      case cilib.exec.Unchanged => List("Unchanged")
+      case cilib.exec.Change => List("Changed")
+    })
 
   implicit def genericEncodeCsv[A, R](
       implicit gen: Generic.Aux[A, R],

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.1.2

--- a/tests/src/test/scala/cilib/MetricSpaceTests.scala
+++ b/tests/src/test/scala/cilib/MetricSpaceTests.scala
@@ -19,7 +19,7 @@ object MetricSpaceTest extends Spec("MetricSpace") {
     Arbitrary.arbitrary[Int => Int].map(MetricSpace.pure[Int, Int => Int])
   }
 
-  implicit val doubleGen = Gen.choose(-100000000.0, 100000000.0)
+  implicit val doubleGen = Gen.choose(-1000000.0, 1000000.0)
 
   val listTuple2 = Gen.sized { size =>
     for {


### PR DESCRIPTION
A bug was found by @stefanvds with the use of a sink in the runner process pipeline. When setting up a pipeline (without using a `measure` function), compilation would cause the compiler to try create a derivation that __never__ completed. I'm actually surprised that the compiler _didn't_ crash, although I suspect letting the compiler continue, without intervention, would eventually result in a crash. The specific case highlighted by @stefanvds had the compiler running for over 20 minutes.

Limiting all sinks to instead only accept `Measurement[A]` values corrects the derivation problem. In retrospect, it makes sense to only allow `Measurement[A]` values to be serialized through the sinks.

Naturally, this does not prevent alternate usage, but to use the sinks defined in the `io` module, a measurement needs to be done to allow the compilation to succeed now, not doing so results in a compiler error (as it should be).