### PR TITLE
Remove unneeded structure constraint

### DIFF
--- a/core/src/main/scala/cilib/Step.scala
+++ b/core/src/main/scala/cilib/Step.scala
@@ -147,7 +147,7 @@ object StepS {
         StepS(M.put(s))
     }
 
-  @deprecated("This method has been deprecated, use pure instead, it is technically more accurate",
+  @deprecated("This method has been deprecated, use liftR instead, it is technically more accurate",
               "2.0.2")
   def pointR[A, S, B](a: RVar[B]): StepS[A, S, B] =
     liftR(a)

--- a/exec/src/main/scala/cilib/Runner.scala
+++ b/exec/src/main/scala/cilib/Runner.scala
@@ -152,15 +152,15 @@ object Runner {
 
   import com.sksamuel.avro4s._
 
-  def measure[F[_], A, S, B](f: F[A] => B)(
-      implicit B: SchemaFor[B]): Process1[Progress[F[A]], Measurement[B]] =
+  def measure[A, S, B](f: A => B)(
+      implicit B: SchemaFor[B]): Process1[Progress[A], Measurement[B]] =
     process1.lift {
       case Progress(algorithm, problem, seed, iteration, env, value) =>
         Measurement(algorithm, problem, iteration, env, seed, f(value))
     }
 
-  def measureWithState[F[_], A, S, B](f: (S, F[A]) => B)(
-      implicit B: SchemaFor[B]): Process1[Progress[(S, F[A])], Measurement[B]] =
+  def measureWithState[A, S, B](f: (S, A) => B)(
+      implicit B: SchemaFor[B]): Process1[Progress[(S, A)], Measurement[B]] =
     process1.lift {
       case Progress(algorithm, problem, seed, iteration, env, (state, value)) =>
         Measurement(algorithm, problem, iteration, env, seed, f(state, value))

--- a/exec/src/main/scala/cilib/Runner.scala
+++ b/exec/src/main/scala/cilib/Runner.scala
@@ -152,8 +152,7 @@ object Runner {
 
   import com.sksamuel.avro4s._
 
-  def measure[A, S, B](f: A => B)(
-      implicit B: SchemaFor[B]): Process1[Progress[A], Measurement[B]] =
+  def measure[A, S, B](f: A => B)(implicit B: SchemaFor[B]): Process1[Progress[A], Measurement[B]] =
     process1.lift {
       case Progress(algorithm, problem, seed, iteration, env, value) =>
         Measurement(algorithm, problem, iteration, env, seed, f(value))


### PR DESCRIPTION
The measurement code does not need to care if the value received is in
fact a `F[A]` or an `A`. The removal of `F[_]` makes the code a little
more flexible without removing functionality.