### PR TITLE
Pass the Eval to onChange for environment handling

### DIFF
--- a/core/src/main/scala/cilib/Environment.scala
+++ b/core/src/main/scala/cilib/Environment.scala
@@ -3,8 +3,7 @@ package cilib
 import scalaz.NonEmptyList
 import monocle._
 
-final class Environment[A] private (val cmp: Comparison,
-                                    val eval: Eval[NonEmptyList, A])
+final class Environment[A] private (val cmp: Comparison, val eval: Eval[NonEmptyList, A])
 
 object Environment {
 
@@ -12,6 +11,5 @@ object Environment {
     new Environment(cmp, eval)
 
   def _eval[A] =
-    Lens[Environment[A], Eval[NonEmptyList, A]](_.eval)(b =>
-      a => new Environment(a.cmp, b))
+    Lens[Environment[A], Eval[NonEmptyList, A]](_.eval)(b => a => new Environment(a.cmp, b))
 }

--- a/core/src/main/scala/cilib/Environment.scala
+++ b/core/src/main/scala/cilib/Environment.scala
@@ -1,0 +1,17 @@
+package cilib
+
+import scalaz.NonEmptyList
+import monocle._
+
+final class Environment[A] private (val cmp: Comparison,
+                                    val eval: Eval[NonEmptyList, A])
+
+object Environment {
+
+  def apply[A](cmp: Comparison, eval: Eval[NonEmptyList, A]) =
+    new Environment(cmp, eval)
+
+  def _eval[A] =
+    Lens[Environment[A], Eval[NonEmptyList, A]](_.eval)(b =>
+      a => new Environment(a.cmp, b))
+}

--- a/core/src/main/scala/cilib/Eval.scala
+++ b/core/src/main/scala/cilib/Eval.scala
@@ -13,7 +13,7 @@ sealed abstract class Eval[F[_], A] {
 
   def run: F[A] => Double
 
-  def eval: RVar[NonEmptyList[A] => Objective[A]] =
+  lazy val eval: RVar[NonEmptyList[A] => Objective[A]] =
     RVar.pure { (fa: NonEmptyList[A]) =>
       this match {
         case Unconstrained(f, _) => Single(Feasible(f(F.toInput(fa))), List.empty)

--- a/core/src/main/scala/cilib/Step.scala
+++ b/core/src/main/scala/cilib/Step.scala
@@ -3,8 +3,6 @@ package cilib
 import scalaz.{Lens => _, _}
 import Scalaz._
 
-final case class Environment[A](cmp: Comparison, eval: RVar[NonEmptyList[A] => Objective[A]]) // This is still questionable?
-
 /**
   A `Step` is a type that models a single step / operation within a CI Algorithm.
 
@@ -89,7 +87,7 @@ object Step {
 
   def evalP[A](pos: Position[A]): Step[A, Position[A]] =
     Cont { env =>
-      Position.eval(env.eval, pos).map(_.right)
+      Position.eval(env.eval.eval, pos).map(_.right)
     }
 
   implicit def stepMonad[A]: Monad[Step[A, ?]] =

--- a/docs/src/main/tut/usage/gbestpso.md
+++ b/docs/src/main/tut/usage/gbestpso.md
@@ -85,7 +85,7 @@ minimizing this problem and defining the bounds of the problem space.
 val env =
   Environment(
     cmp = Comparison.dominance(Min),
-    eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+    eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
 val bounds = Interval(-5.12,5.12)^30
 ```

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -20,9 +20,9 @@ object GAExample extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
 
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   def onePoint(xs: List[Ind]): RVar[List[Ind]] =
     xs match {

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -22,7 +22,7 @@ object GAExample extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   def onePoint(xs: List[Ind]): RVar[List[Ind]] =
     xs match {

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -16,9 +16,9 @@ import spire.math.Interval
 object GBestPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]
@@ -34,12 +34,15 @@ object GBestPSO extends SafeApp {
 
   // Our IO[Unit] that runs the algorithm, at the end of the world
   override val runc: IO[Unit] = {
-    val t = Runner.foldStep(env,
-                            RNG.fromTime,
-                            swarm,
-                            Runner.staticAlgorithm("gbestPSO", iter),
-                            problemStream,
-                            (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) => RVar.pure(x))
+    val t = Runner.foldStep(
+      env,
+      RNG.fromTime,
+      swarm,
+      Runner.staticAlgorithm("gbestPSO", iter),
+      problemStream,
+      (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) =>
+        RVar.pure(x)
+    )
 
     putStrLn(t.take(1000).runLast.unsafePerformSync.toString)
   }

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -18,7 +18,7 @@ object GBestPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]
@@ -30,7 +30,7 @@ object GBestPSO extends SafeApp {
     Position.createCollection(PSO.createParticle(x => Entity(Mem(x, x.zeroed), x)))(bounds, 20)
   val iter = Iteration.sync(gbestPSO)
 
-  val problemStream = Runner.staticProblem("spherical", env.eval, RNG.init(123L))
+  val problemStream = Runner.staticProblem("spherical", env.eval)
 
   // Our IO[Unit] that runs the algorithm, at the end of the world
   override val runc: IO[Unit] = {
@@ -39,7 +39,7 @@ object GBestPSO extends SafeApp {
                             swarm,
                             Runner.staticAlgorithm("gbestPSO", iter),
                             problemStream,
-                            (x: NonEmptyList[Particle[Mem[Double], Double]]) => RVar.pure(x))
+                            (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) => RVar.pure(x))
 
     putStrLn(t.take(1000).runLast.unsafePerformSync.toString)
   }

--- a/example/src/main/scala/cilib/example/GCPSO.scala
+++ b/example/src/main/scala/cilib/example/GCPSO.scala
@@ -21,7 +21,7 @@ object GCPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]

--- a/example/src/main/scala/cilib/example/GCPSO.scala
+++ b/example/src/main/scala/cilib/example/GCPSO.scala
@@ -19,9 +19,9 @@ object GCPSO extends SafeApp {
 
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]

--- a/example/src/main/scala/cilib/example/Heterogeneous.scala
+++ b/example/src/main/scala/cilib/example/Heterogeneous.scala
@@ -101,9 +101,9 @@ object HPSO extends SafeApp {
 
   val bounds = Interval(-5.12, 5.12) ^ 2
   val env =
-    Environment(
-      cmp = Comparison.quality(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.quality(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val population =
     StepS

--- a/example/src/main/scala/cilib/example/Heterogeneous.scala
+++ b/example/src/main/scala/cilib/example/Heterogeneous.scala
@@ -103,7 +103,7 @@ object HPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.quality(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val population =
     StepS

--- a/example/src/main/scala/cilib/example/LBestPSO.scala
+++ b/example/src/main/scala/cilib/example/LBestPSO.scala
@@ -16,9 +16,9 @@ import cilib.exec._
 object LBestPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.quality(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.quality(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // LBest is a network topology where every Paricle 'x' has (n/2) neighbours
   // on each side. For example, a neighbourhood size of 3 means that there is

--- a/example/src/main/scala/cilib/example/LBestPSO.scala
+++ b/example/src/main/scala/cilib/example/LBestPSO.scala
@@ -18,7 +18,7 @@ object LBestPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.quality(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // LBest is a network topology where every Paricle 'x' has (n/2) neighbours
   // on each side. For example, a neighbourhood size of 3 means that there is

--- a/example/src/main/scala/cilib/example/Mixed.scala
+++ b/example/src/main/scala/cilib/example/Mixed.scala
@@ -21,7 +21,7 @@ object Mixed extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // Define the DE
   val de = DE.de(0.5, 0.5, DE.randSelection[Mem[Double], Double], 1, DE.bin[Position, Double])

--- a/example/src/main/scala/cilib/example/Mixed.scala
+++ b/example/src/main/scala/cilib/example/Mixed.scala
@@ -19,9 +19,9 @@ object Mixed extends SafeApp {
 
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // Define the DE
   val de = DE.de(0.5, 0.5, DE.randSelection[Mem[Double], Double], 1, DE.bin[Position, Double])

--- a/example/src/main/scala/cilib/example/NMPCPSO.scala
+++ b/example/src/main/scala/cilib/example/NMPCPSO.scala
@@ -17,9 +17,9 @@ object NMPCPSO extends SafeApp {
 
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.quality(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.quality(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val guide = Guide.nmpc[Mem[Double]](0.5)
   val nmpcPSO = nmpc(guide)

--- a/example/src/main/scala/cilib/example/NMPCPSO.scala
+++ b/example/src/main/scala/cilib/example/NMPCPSO.scala
@@ -19,7 +19,7 @@ object NMPCPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.quality(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val guide = Guide.nmpc[Mem[Double]](0.5)
   val nmpcPSO = nmpc(guide)

--- a/example/src/main/scala/cilib/example/PCXPSO.scala
+++ b/example/src/main/scala/cilib/example/PCXPSO.scala
@@ -16,9 +16,9 @@ import spire.math.Interval
 object PCXPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val guide = Guide.pcx[Mem[Double]](2.0, 2.0)
   val pcxPSO = crossoverPSO(guide)

--- a/example/src/main/scala/cilib/example/PCXPSO.scala
+++ b/example/src/main/scala/cilib/example/PCXPSO.scala
@@ -18,7 +18,7 @@ object PCXPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val guide = Guide.pcx[Mem[Double]](2.0, 2.0)
   val pcxPSO = crossoverPSO(guide)

--- a/example/src/main/scala/cilib/example/RandomSearchGA.scala
+++ b/example/src/main/scala/cilib/example/RandomSearchGA.scala
@@ -20,7 +20,7 @@ object RandomSearchGA extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val randomSelection = (l: NonEmptyList[Ind]) => RVar.sample(2, l).getOrElse(List.empty[Ind])
   val distribution = (position: Double) =>

--- a/example/src/main/scala/cilib/example/RandomSearchGA.scala
+++ b/example/src/main/scala/cilib/example/RandomSearchGA.scala
@@ -18,9 +18,9 @@ object RandomSearchGA extends SafeApp {
 
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val randomSelection = (l: NonEmptyList[Ind]) => RVar.sample(2, l).getOrElse(List.empty[Ind])
   val distribution = (position: Double) =>

--- a/example/src/main/scala/cilib/example/TimeVaryingGBestPSO.scala
+++ b/example/src/main/scala/cilib/example/TimeVaryingGBestPSO.scala
@@ -16,9 +16,9 @@ import spire.math.Interval
 object TimeVaryingGBestPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // To define one or more parameters for an algorithm, we need a few pieces:
 
@@ -67,7 +67,8 @@ object TimeVaryingGBestPSO extends SafeApp {
                        mkAlgorithm,
                        updateParams),
       problemStream,
-      (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) => RVar.pure(x)
+      (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) =>
+        RVar.pure(x)
     )
 
     putStrLn(t.take(1000).runLast.unsafePerformSync.toString)

--- a/example/src/main/scala/cilib/example/TimeVaryingGBestPSO.scala
+++ b/example/src/main/scala/cilib/example/TimeVaryingGBestPSO.scala
@@ -18,7 +18,7 @@ object TimeVaryingGBestPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // To define one or more parameters for an algorithm, we need a few pieces:
 
@@ -53,7 +53,7 @@ object TimeVaryingGBestPSO extends SafeApp {
   val swarm =
     Position.createCollection(PSO.createParticle(x => Entity(Mem(x, x.zeroed), x)))(bounds, 20)
 
-  val problemStream = Runner.staticProblem("spherical", env.eval, RNG.init(123L))
+  val problemStream = Runner.staticProblem("spherical", env.eval)
 
   // Our IO[Unit] that runs the algorithm, at the end of the world
   override val runc: IO[Unit] = {
@@ -67,7 +67,7 @@ object TimeVaryingGBestPSO extends SafeApp {
                        mkAlgorithm,
                        updateParams),
       problemStream,
-      (x: NonEmptyList[Particle[Mem[Double], Double]]) => RVar.pure(x)
+      (x: NonEmptyList[Particle[Mem[Double], Double]], _: Eval[NonEmptyList, Double]) => RVar.pure(x)
     )
 
     putStrLn(t.take(1000).runLast.unsafePerformSync.toString)

--- a/example/src/main/scala/cilib/example/UNDXPSO.scala
+++ b/example/src/main/scala/cilib/example/UNDXPSO.scala
@@ -16,9 +16,9 @@ import spire.math.Interval
 object UNDXPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val guide = Guide.undx[Mem[Double]](1.0, 0.1)
   val undxPSO = crossoverPSO(guide)

--- a/example/src/main/scala/cilib/example/UNDXPSO.scala
+++ b/example/src/main/scala/cilib/example/UNDXPSO.scala
@@ -18,7 +18,7 @@ object UNDXPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   val guide = Guide.undx[Mem[Double]](1.0, 0.1)
   val undxPSO = crossoverPSO(guide)

--- a/example/src/main/scala/cilib/example/VonNeumannPSO.scala
+++ b/example/src/main/scala/cilib/example/VonNeumannPSO.scala
@@ -19,7 +19,7 @@ object VonNeumannPSO extends SafeApp {
   val env =
     Environment(
       cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]).eval)
+      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]

--- a/example/src/main/scala/cilib/example/VonNeumannPSO.scala
+++ b/example/src/main/scala/cilib/example/VonNeumannPSO.scala
@@ -17,9 +17,9 @@ object VonNeumannPSO extends SafeApp {
 
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
-    Environment(
-      cmp = Comparison.dominance(Min),
-      eval = Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+    Environment(cmp = Comparison.dominance(Min),
+                eval =
+                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]

--- a/exec/src/main/scala/cilib/Runner.scala
+++ b/exec/src/main/scala/cilib/Runner.scala
@@ -14,7 +14,7 @@ import eu.timepit.refined.collection._
 final case class Algorithm[A](name: String Refined NonEmpty, value: A)
 final case class Problem[A](name: String Refined NonEmpty,
                             env: Env,
-                            eval: RVar[NonEmptyList[A] => Objective[A]])
+                            eval: Eval[NonEmptyList, A])
 final case class Progress[A] private (algorithm: String,
                                       problem: String,
                                       seed: Long,
@@ -56,12 +56,10 @@ object Runner {
 
   def staticProblem[S, A](
       name: String Refined NonEmpty,
-      eval: RVar[NonEmptyList[A] => Objective[A]],
-      rng: RNG
-  ): Process[Task, Problem[A]] = {
-    val (_, e) = eval.run(rng)
-    Process.constant(Problem(name, Unchanged, RVar.pure(e)))
-  }
+      eval: Eval[NonEmptyList, A]
+  ): Process[Task, Problem[A]] =
+    Process.constant(Problem(name, Unchanged, eval))
+
 
   def problem[S, A](name: String Refined NonEmpty,
                     state: RVar[S],
@@ -75,11 +73,11 @@ object Runner {
         case h #:: t =>
           h match {
             case Unchanged =>
-              Process.emit(Problem(name, h, c.eval)) ++ go(s, c, t, r)
+              Process.emit(Problem(name, h, c)) ++ go(s, c, t, r)
 
             case Change =>
               val (rng2, (s1, c1)) = next(s).run(r)
-              Process.emit(Problem(name, h, c1.eval)) ++ go(s1, c1, t, rng2)
+              Process.emit(Problem(name, h, c1)) ++ go(s1, c1, t, rng2)
           }
       }
 
@@ -95,7 +93,7 @@ object Runner {
                            collection: RVar[F[B]],
                            alg: Process[Task, Algorithm[Kleisli[Step[A, ?], F[B], F[B]]]],
                            env: Process[Task, Problem[A]],
-                           onChange: F[B] => RVar[F[B]]): Process[Task, Progress[F[B]]] = {
+                           onChange: (F[B], Eval[NonEmptyList, A]) => RVar[F[B]]): Process[Task, Progress[F[B]]] = {
 
     // Convert to a StepS with Unit as the state parameter
     val a: Process[Task, Algorithm[Kleisli[StepS[A, Unit, ?], F[B], F[B]]]] =
@@ -111,7 +109,7 @@ object Runner {
                                collection: RVar[F[B]],
                                alg: Process[Task, Algorithm[Kleisli[StepS[A, S, ?], F[B], F[B]]]],
                                env: Process[Task, Problem[A]],
-                               onChange: F[B] => RVar[F[B]]): Process[Task, Progress[(S, F[B])]] = {
+                               onChange: (F[B], Eval[NonEmptyList, A]) => RVar[F[B]]): Process[Task, Progress[(S, F[B])]] = {
 
     def go(iteration: Int, r: RNG, current: F[B], config: Environment[A], state: S)
       : Tee[Problem[A], Algorithm[Kleisli[StepS[A, S, ?], F[B], F[B]]], Progress[(S, F[B])]] =
@@ -121,17 +119,17 @@ object Runner {
           Process.awaitR[Algorithm[Kleisli[StepS[A, S, ?], F[B], F[B]]]].awaitOption.flatMap {
             case None => Process.halt
             case Some(algorithm) =>
-              val newConfig: Environment[A] =
+              val newConfig =
                 e match {
                   case Unchanged => config
-                  case Change    => config.copy(eval = eval)
+                  case Change    => Environment._eval[A].set(eval)(config)
                 }
 
               val (r2, next) =
                 e match {
                   case Unchanged => algorithm.value.run(current).run(state).run(newConfig).run(r)
                   case Change =>
-                    val (r3, updated) = onChange(current).run(r)
+                    val (r3, updated) = onChange(current, newConfig.eval).run(r)
                     algorithm.value.run(updated).run(state).run(newConfig).run(r3)
                 }
 

--- a/exec/src/main/scala/cilib/Runner.scala
+++ b/exec/src/main/scala/cilib/Runner.scala
@@ -12,9 +12,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.collection._
 
 final case class Algorithm[A](name: String Refined NonEmpty, value: A)
-final case class Problem[A](name: String Refined NonEmpty,
-                            env: Env,
-                            eval: Eval[NonEmptyList, A])
+final case class Problem[A](name: String Refined NonEmpty, env: Env, eval: Eval[NonEmptyList, A])
 final case class Progress[A] private (algorithm: String,
                                       problem: String,
                                       seed: Long,
@@ -60,7 +58,6 @@ object Runner {
   ): Process[Task, Problem[A]] =
     Process.constant(Problem(name, Unchanged, eval))
 
-
   def problem[S, A](name: String Refined NonEmpty,
                     state: RVar[S],
                     next: S => RVar[(S, Eval[NonEmptyList, A])])(
@@ -88,12 +85,13 @@ object Runner {
   /**
     *  Interpreter for algorithm execution
     */
-  def foldStep[F[_], A, B](initialConfig: Environment[A],
-                           rng: RNG,
-                           collection: RVar[F[B]],
-                           alg: Process[Task, Algorithm[Kleisli[Step[A, ?], F[B], F[B]]]],
-                           env: Process[Task, Problem[A]],
-                           onChange: (F[B], Eval[NonEmptyList, A]) => RVar[F[B]]): Process[Task, Progress[F[B]]] = {
+  def foldStep[F[_], A, B](
+      initialConfig: Environment[A],
+      rng: RNG,
+      collection: RVar[F[B]],
+      alg: Process[Task, Algorithm[Kleisli[Step[A, ?], F[B], F[B]]]],
+      env: Process[Task, Problem[A]],
+      onChange: (F[B], Eval[NonEmptyList, A]) => RVar[F[B]]): Process[Task, Progress[F[B]]] = {
 
     // Convert to a StepS with Unit as the state parameter
     val a: Process[Task, Algorithm[Kleisli[StepS[A, Unit, ?], F[B], F[B]]]] =
@@ -103,13 +101,14 @@ object Runner {
       .map(x => x.copy(value = x.value._2))
   }
 
-  def foldStepS[F[_], S, A, B](initialConfig: Environment[A],
-                               initialState: S,
-                               rng: RNG,
-                               collection: RVar[F[B]],
-                               alg: Process[Task, Algorithm[Kleisli[StepS[A, S, ?], F[B], F[B]]]],
-                               env: Process[Task, Problem[A]],
-                               onChange: (F[B], Eval[NonEmptyList, A]) => RVar[F[B]]): Process[Task, Progress[(S, F[B])]] = {
+  def foldStepS[F[_], S, A, B](
+      initialConfig: Environment[A],
+      initialState: S,
+      rng: RNG,
+      collection: RVar[F[B]],
+      alg: Process[Task, Algorithm[Kleisli[StepS[A, S, ?], F[B], F[B]]]],
+      env: Process[Task, Problem[A]],
+      onChange: (F[B], Eval[NonEmptyList, A]) => RVar[F[B]]): Process[Task, Progress[(S, F[B])]] = {
 
     def go(iteration: Int, r: RNG, current: F[B], config: Environment[A], state: S)
       : Tee[Problem[A], Algorithm[Kleisli[StepS[A, S, ?], F[B], F[B]]], Progress[(S, F[B])]] =

--- a/tests/src/test/scala/cilib/PSOTests.scala
+++ b/tests/src/test/scala/cilib/PSOTests.scala
@@ -36,7 +36,7 @@ object PSOTests extends Properties("QPSO") {
       val p = Entity(Mem(x, x.zeroed), x)
       val env = Environment(
         cmp = Comparison.dominance(Min),
-        eval = Eval.unconstrained((x: NonEmptyList[Double]) => 0.0).eval)
+        eval = Eval.unconstrained((x: NonEmptyList[Double]) => 0.0))
 
       val (_, result) =
         cilib.pso.PSO.quantum(p.pos, RVar.pure(10.0), (a,b) => Dist.uniform(spire.math.Interval(a,b)))

--- a/tests/src/test/scala/cilib/StepTest.scala
+++ b/tests/src/test/scala/cilib/StepTest.scala
@@ -10,7 +10,7 @@ object StepTest extends Spec("Step") {
   val rng = RNG.fromTime
   val env = Environment(
     cmp = Comparison.quality(Min),
-    eval = Eval.unconstrained((l: NonEmptyList[Int]) => l.list.foldLeft(0.0)(_ + _)).eval)
+    eval = Eval.unconstrained((l: NonEmptyList[Int]) => l.list.foldLeft(0.0)(_ + _)))
 
   implicit def stepEqual = scalaz.Equal[Int].contramap((_: Step[Int,Int]).run(env).run(rng)._2.fold(l => 0, r => r))
   implicit def stepSEqual = scalaz.Equal[Int].contramap((_: StepS[Int,Int,Int]).run.apply(3).run(env).run(rng)._2.fold(l => 0, r => r._2))


### PR DESCRIPTION
When a dynamic environment changes, some handling mechanisms require
a modification to the entity collection. A trivial example would be
that the fitness values are potentially no longer valid for the entity
collection after an environment change.