### PR TITLE
Correct `choices` function

### DIFF
--- a/core/src/main/scala/cilib/MetricSpace.scala
+++ b/core/src/main/scala/cilib/MetricSpace.scala
@@ -37,23 +37,29 @@ trait MetricSpace[A, B] { self =>
 object MetricSpace {
   def levenshtein[B](implicit B: Integral[B]): MetricSpace[String, B] =
     new MetricSpace[String, B] {
+      type Memo = Map[(Int, Int), Int]
 
       def dist(x: String, y: String): B = {
-        def f(i: Int, j: Int): State[Map[(Int, Int), Int], Int] =
+        def f(i: Int, j: Int): State[Memo, Int] =
           (i, j) match {
             case (i, 0) => State(s => (s, i))
             case (0, j) => State(s => (s, j))
             case (i, j) =>
-              for {
-                a <- f(i - 1, j)
-                b <- f(i, j - 1)
-                c <- f(i - 1, j - 1)
-              } yield
-                NonEmptyList(
-                  a + 1,
-                  b + 1,
-                  c + (if (x(i - 1) == y(j - 1)) 0 else 1)
-                ).minimum1
+              State(memo =>
+                memo.get((i, j)) match {
+                  case Some(value) => (memo, value)
+                  case None =>
+                    (for {
+                      a <- f(i - 1, j)
+                      b <- f(i, j - 1)
+                      c <- f(i - 1, j - 1)
+                    } yield
+                      NonEmptyList(
+                        a + 1,
+                        b + 1,
+                        c + (if (x(i - 1) == y(j - 1)) 0 else 1)
+                      ).minimum1).run(memo)
+              })
           }
 
         B.fromInt(f(x.length, y.length).eval(Map.empty))

--- a/tests/src/test/scala/cilib/RVarTests.scala
+++ b/tests/src/test/scala/cilib/RVarTests.scala
@@ -27,6 +27,24 @@ object RVarTests extends Spec("RVar") {
     Arbitrary.arbitrary[Int => Int].map(RVar.pure(_))
   }
 
+  def distinctListOf[A:Arbitrary:scalaz.Order] =
+    distinctListOfGen(Arbitrary.arbitrary[A])
+
+  def distinctListOfGen[A](gen: Gen[A])(implicit E: scalaz.Order[A]): Gen[List[A]] = {
+    @annotation.tailrec
+    def go(discarded: Int, acc: List[A]): List[A] = {
+      if (discarded >= 10) acc
+      else
+        gen.sample match {
+          case Some(x) if !acc.exists(a => E.equal(a, x)) =>
+            go(discarded, acc :+ x)
+          case _    => go(discarded + 1, acc)
+        }
+    }
+
+    Gen.choose(0, 10).flatMap(n => Gen.const(go(0, List.empty[A])))
+  }
+
   checkAll(equal.laws[RVar[Int]])
   checkAll(monad.laws[RVar])
   checkAll(bindRec.laws[RVar])
@@ -38,14 +56,16 @@ object RVarTests extends Spec("RVar") {
     }
 
   property("sampling") =
-    forAll { (n: Int, xs: List[Int]) =>
-      (n > 0) ==> (refineV[Positive](n) match {
-        case Left(error) => false :| error
+    forAll(Gen.choose(1, 10), distinctListOf[Int]) { (n: Int, xs: List[Int]) =>
+      refineV[Positive](n) match {
+        case Left(error) => false :| s"Cannot refine: $error"
         case Right(value) =>
-          val selected: List[Int] = RVar.sample(value, xs).run(rng)._2.getOrElse(List.empty)
+          val selected: List[Int] =
+            // Using distinct here is safe as we are comparing Int values and not more complex data types
+            RVar.sample(value, xs).run(rng)._2.getOrElse(List.empty).distinct
 
           if (xs.length < n) selected.isEmpty :| s"Resulting list [$selected] does not have length $n"
-          else (selected.length == n) :| s"Error => n: $n, $selected, length: ${selected.length}, xs.length: ${xs.length}, xs: $xs"
-      })
+          else (selected.length == n) :| s"Error => $n, selected length: ${selected.length}, xs.length: ${xs.length}, xs: $xs\nselected: $selected"
+      }
     }
 }


### PR DESCRIPTION
The function was returning invalid results due to referencing the
wrong data structure. Some additional logic is now also included to
make sure that the operation behaves a little more efficiently.

`MetricSpace` did not use the memoization scheme correctly, resulting
in no benefit actually being present. This is now correct, referencing
the memoization map structure.