### PR TITLE
Fitness functions should determine fitness viability

### DIFF
--- a/core/src/main/scala/cilib/Eval.scala
+++ b/core/src/main/scala/cilib/Eval.scala
@@ -11,16 +11,24 @@ sealed abstract class Eval[F[_], A] {
 
   val F: Input[F]
 
-  def run: F[A] => Double
+  def run: F[A] => Fit
 
   lazy val eval: RVar[NonEmptyList[A] => Objective[A]] =
     RVar.pure { (fa: NonEmptyList[A]) =>
       this match {
-        case Unconstrained(f, _) => Objective.single(Feasible(f(F.toInput(fa))), List.empty)
+        case Unconstrained(f, _) => Objective.single(f(F.toInput(fa)), List.empty)
         case Constrained(f, cs, _) =>
           cs.filter(c => !Constraint.satisfies(c, fa)) match {
-            case Nil => Objective.single(Feasible(f(F.toInput(fa))), List.empty)
-            case xs  => Objective.single(Infeasible(f(F.toInput(fa))), xs)
+            case Nil => Objective.single(f(F.toInput(fa)), List.empty)
+            case xs =>
+              val result =
+                f(F.toInput(fa)) match {
+                  case Feasible(v)       => Infeasible(v)
+                  case Adjusted(_, a)    => Infeasible(a)
+                  case i @ Infeasible(_) => i
+                }
+
+              Objective.single(result, xs)
           }
       }
     }
@@ -33,17 +41,16 @@ sealed abstract class Eval[F[_], A] {
 }
 
 object Eval {
-  private final case class Unconstrained[F[_], A](run: F[A] => Double, F: Input[F])
-      extends Eval[F, A]
-  private final case class Constrained[F[_], A](run: F[A] => Double,
+  private final case class Unconstrained[F[_], A](run: F[A] => Fit, F: Input[F]) extends Eval[F, A]
+  private final case class Constrained[F[_], A](run: F[A] => Fit,
                                                 cs: List[Constraint[A]],
                                                 F: Input[F])
       extends Eval[F, A]
 
-  def unconstrained[F[_], A](f: F[A] => Double)(implicit F: Input[F]): Eval[F, A] =
+  def unconstrained[F[_], A](f: F[A] => Fit)(implicit F: Input[F]): Eval[F, A] =
     Unconstrained(f, F)
 
-  def constrained[F[_], A](f: F[A] => Double, cs: List[Constraint[A]])(
+  def constrained[F[_], A](f: F[A] => Fit, cs: List[Constraint[A]])(
       implicit F: Input[F]): Eval[F, A] =
     Constrained(f, cs, F)
 }

--- a/example/src/main/scala/cilib/example/FileOutput.scala
+++ b/example/src/main/scala/cilib/example/FileOutput.scala
@@ -29,22 +29,19 @@ object FileOutput extends SafeApp {
   // Define the benchmarks
   val absolute = Environment(
     cmp = Comparison.dominance(Max),
-    eval = Eval.unconstrained(Benchmarks.absoluteValue[NonEmptyList, Double])
-  )
+    eval = Eval.unconstrained((xs: NonEmptyList[Double]) => Feasible(Benchmarks.absoluteValue(xs))))
 
   val ackley = Environment(
     cmp = Comparison.dominance(Max),
-    eval = Eval.unconstrained(Benchmarks.ackley[NonEmptyList, Double])
-  )
+    eval = Eval.unconstrained((xs: NonEmptyList[Double]) => Feasible(Benchmarks.ackley(xs))))
+
   val quadric = Environment(
     cmp = Comparison.dominance(Max),
-    eval = Eval.unconstrained(Benchmarks.quadric[NonEmptyList, Double])
-  )
+    eval = Eval.unconstrained((xs: NonEmptyList[Double]) => Feasible(Benchmarks.quadric(xs))))
 
   val spherical = Environment(
     cmp = Comparison.dominance(Max),
-    eval = Eval.unconstrained(Benchmarks.spherical[NonEmptyList, Double])
-  )
+    eval = Eval.unconstrained((xs: NonEmptyList[Double]) => Feasible(Benchmarks.spherical(xs))))
 
   // Define the problem streams
   val absoluteStream = Runner.staticProblem("absolute", absolute.eval)

--- a/example/src/main/scala/cilib/example/GA.scala
+++ b/example/src/main/scala/cilib/example/GA.scala
@@ -21,8 +21,8 @@ object GAExample extends SafeApp {
 
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   def onePoint(xs: List[Ind]): RVar[List[Ind]] =
     xs match {

--- a/example/src/main/scala/cilib/example/GBestPSO.scala
+++ b/example/src/main/scala/cilib/example/GBestPSO.scala
@@ -17,8 +17,8 @@ object GBestPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]

--- a/example/src/main/scala/cilib/example/GCPSO.scala
+++ b/example/src/main/scala/cilib/example/GCPSO.scala
@@ -20,8 +20,8 @@ object GCPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]

--- a/example/src/main/scala/cilib/example/Heterogeneous.scala
+++ b/example/src/main/scala/cilib/example/Heterogeneous.scala
@@ -102,8 +102,8 @@ object HPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 2
   val env =
     Environment(cmp = Comparison.quality(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   val population =
     StepS

--- a/example/src/main/scala/cilib/example/LBestPSO.scala
+++ b/example/src/main/scala/cilib/example/LBestPSO.scala
@@ -17,8 +17,8 @@ object LBestPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.quality(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   // LBest is a network topology where every Paricle 'x' has (n/2) neighbours
   // on each side. For example, a neighbourhood size of 3 means that there is

--- a/example/src/main/scala/cilib/example/Mixed.scala
+++ b/example/src/main/scala/cilib/example/Mixed.scala
@@ -20,8 +20,8 @@ object Mixed extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   // Define the DE
   val de = DE.de(0.5, 0.5, DE.randSelection[Mem[Double], Double], 1, DE.bin[Position, Double])

--- a/example/src/main/scala/cilib/example/NMPCPSO.scala
+++ b/example/src/main/scala/cilib/example/NMPCPSO.scala
@@ -18,8 +18,8 @@ object NMPCPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.quality(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   val guide = Guide.nmpc[Mem[Double]](0.5)
   val nmpcPSO = nmpc(guide)

--- a/example/src/main/scala/cilib/example/PCXPSO.scala
+++ b/example/src/main/scala/cilib/example/PCXPSO.scala
@@ -17,8 +17,8 @@ object PCXPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   val guide = Guide.pcx[Mem[Double]](2.0, 2.0)
   val pcxPSO = crossoverPSO(guide)

--- a/example/src/main/scala/cilib/example/Problems.scala
+++ b/example/src/main/scala/cilib/example/Problems.scala
@@ -148,7 +148,7 @@ object Problems {
   def peakEval(peaks: NonEmptyList[PeakCone]): Eval[NonEmptyList, Double] =
     Eval.unconstrained((a: NonEmptyList[Double]) => {
       val x = peaks.map(_.eval(a)).list.toList.max // FIXME
-      val r = if (x == Double.NaN) 0.0 else x
+      val r = if (x == Double.NaN) Infeasible(0.0) else Feasible(x)
 
       r
     })

--- a/example/src/main/scala/cilib/example/RandomSearchGA.scala
+++ b/example/src/main/scala/cilib/example/RandomSearchGA.scala
@@ -19,8 +19,8 @@ object RandomSearchGA extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   val randomSelection = (l: NonEmptyList[Ind]) => RVar.sample(2, l).map(_.getOrElse(List.empty))
   val distribution = (position: Double) =>

--- a/example/src/main/scala/cilib/example/TimeVaryingGBestPSO.scala
+++ b/example/src/main/scala/cilib/example/TimeVaryingGBestPSO.scala
@@ -17,8 +17,8 @@ object TimeVaryingGBestPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   // To define one or more parameters for an algorithm, we need a few pieces:
 

--- a/example/src/main/scala/cilib/example/UNDXPSO.scala
+++ b/example/src/main/scala/cilib/example/UNDXPSO.scala
@@ -17,8 +17,8 @@ object UNDXPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   val guide = Guide.undx[Mem[Double]](1.0, 0.1)
   val undxPSO = crossoverPSO(guide)

--- a/example/src/main/scala/cilib/example/VonNeumannPSO.scala
+++ b/example/src/main/scala/cilib/example/VonNeumannPSO.scala
@@ -18,8 +18,8 @@ object VonNeumannPSO extends SafeApp {
   val bounds = Interval(-5.12, 5.12) ^ 30
   val env =
     Environment(cmp = Comparison.dominance(Min),
-                eval =
-                  Eval.unconstrained(cilib.benchmarks.Benchmarks.spherical[NonEmptyList, Double]))
+                eval = Eval.unconstrained((xs: NonEmptyList[Double]) =>
+                  Feasible(cilib.benchmarks.Benchmarks.spherical(xs))))
 
   // Define a normal GBest PSO and run it for a single iteration
   val cognitive = Guide.pbest[Mem[Double], Double]

--- a/tests/src/test/scala/cilib/PSOTests.scala
+++ b/tests/src/test/scala/cilib/PSOTests.scala
@@ -36,7 +36,7 @@ object PSOTests extends Properties("QPSO") {
       val p = Entity(Mem(x, x.zeroed), x)
       val env = Environment(
         cmp = Comparison.dominance(Min),
-        eval = Eval.unconstrained((x: NonEmptyList[Double]) => 0.0))
+        eval = Eval.unconstrained((x: NonEmptyList[Double]) => Feasible(0.0)))
 
       val (_, result) =
         cilib.pso.PSO.quantum(p.pos, RVar.pure(10.0), (a,b) => Dist.uniform(spire.math.Interval(a,b)))

--- a/tests/src/test/scala/cilib/StepTest.scala
+++ b/tests/src/test/scala/cilib/StepTest.scala
@@ -10,7 +10,7 @@ object StepTest extends Spec("Step") {
   val rng = RNG.fromTime
   val env = Environment(
     cmp = Comparison.quality(Min),
-    eval = Eval.unconstrained((l: NonEmptyList[Int]) => l.list.foldLeft(0.0)(_ + _)))
+    eval = Eval.unconstrained((l: NonEmptyList[Int]) => Feasible(l.list.foldLeft(0.0)(_ + _))))
 
   implicit def stepEqual = scalaz.Equal[Int].contramap((_: Step[Int,Int]).run(env).run(rng)._2.fold(l => 0, r => r))
   implicit def stepSEqual = scalaz.Equal[Int].contramap((_: StepS[Int,Int,Int]).run.apply(3).run(env).run(rng)._2.fold(l => 0, r => r._2))


### PR DESCRIPTION
This is a complete oversight: the provided function to the `Eval`
constructors should contain the logic to determine if a fitness value
is "good" or "bad". This necessitates that the fitness function return
the _type_ of fitness (which the quantification represents) instead of
a plain raw value. Doing so will allow for proper comparisons to
occur, based on the logic within the quantification function
itself. Currently, all results are seemingly "feasible" which, is not
the desired behaviour.